### PR TITLE
refactor: Code simplification and helper extraction

### DIFF
--- a/offset/cursor.go
+++ b/offset/cursor.go
@@ -20,22 +20,19 @@ func DecodeCursor(input *string) int {
 		return 0
 	}
 
-	var decoded []byte
-	var data []string
-	var err error
-
-	if decoded, err = base64.URLEncoding.DecodeString(*input); err != nil {
+	decoded, err := base64.URLEncoding.DecodeString(*input)
+	if err != nil {
 		return 0
 	}
 
-	if data = strings.Split(string(decoded), ":"); len(data) == 3 {
-		offset, err := strconv.ParseInt(data[2], 10, 32)
-
-		if err != nil {
-			return 0
-		}
-		return int(offset)
+	parts := strings.Split(string(decoded), ":")
+	if len(parts) != 3 {
+		return 0
 	}
 
-	return 0
+	offset, err := strconv.ParseInt(parts[2], 10, 32)
+	if err != nil {
+		return 0
+	}
+	return int(offset)
 }

--- a/page_args.go
+++ b/page_args.go
@@ -60,17 +60,3 @@ func (pa *PageArgs) GetAfter() *string {
 func (pa *PageArgs) GetSortBy() []Sort {
 	return pa.SortBy
 }
-
-// PageInfo contains metadata about a paginated result set.
-// It uses function fields to enable lazy evaluation of pagination metadata,
-// which is useful when some information (like total count) may be expensive to compute.
-//
-// All functions return both a value and an error to support async computation
-// or database queries that may fail.
-type PageInfo struct {
-	TotalCount      func() (*int, error)
-	HasPreviousPage func() (bool, error)
-	HasNextPage     func() (bool, error)
-	StartCursor     func() (*string, error)
-	EndCursor       func() (*string, error)
-}

--- a/page_args_test.go
+++ b/page_args_test.go
@@ -73,3 +73,29 @@ var _ = Describe("PageArgs", func() {
 		})
 	})
 })
+
+var _ = Describe("NewEmptyPageInfo", func() {
+	It("should return empty PageInfo with nil/false values", func() {
+		pageInfo := paging.NewEmptyPageInfo()
+
+		totalCount, err := pageInfo.TotalCount()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(totalCount).To(BeNil())
+
+		startCursor, err := pageInfo.StartCursor()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(startCursor).To(BeNil())
+
+		endCursor, err := pageInfo.EndCursor()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(endCursor).To(BeNil())
+
+		hasNext, err := pageInfo.HasNextPage()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hasNext).To(BeFalse())
+
+		hasPrev, err := pageInfo.HasPreviousPage()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hasPrev).To(BeFalse())
+	})
+})

--- a/page_info.go
+++ b/page_info.go
@@ -1,0 +1,45 @@
+package paging
+
+// PageInfo contains metadata about a paginated result set.
+// It uses function fields to enable lazy evaluation of pagination metadata,
+// which is useful when some information (like total count) may be expensive to compute.
+//
+// All functions return both a value and an error to support async computation
+// or database queries that may fail.
+type PageInfo struct {
+	TotalCount      func() (*int, error)
+	HasPreviousPage func() (bool, error)
+	HasNextPage     func() (bool, error)
+	StartCursor     func() (*string, error)
+	EndCursor       func() (*string, error)
+}
+
+// NewEmptyPageInfo returns an empty instance of PageInfo.
+// This is useful when you need to satisfy PageInfo requirements but don't have
+// pagination data yet (e.g., empty result sets, error cases, or placeholder responses).
+//
+// All functions return nil or false:
+//   - TotalCount: nil
+//   - StartCursor: nil
+//   - EndCursor: nil
+//   - HasNextPage: false
+//   - HasPreviousPage: false
+//
+// Example usage:
+//
+//	if len(items) == 0 {
+//	    return &Connection{
+//	        Nodes:    []Item{},
+//	        Edges:    []Edge[Item]{},
+//	        PageInfo: NewEmptyPageInfo(),
+//	    }, nil
+//	}
+func NewEmptyPageInfo() PageInfo {
+	return PageInfo{
+		TotalCount:      func() (*int, error) { return nil, nil },
+		StartCursor:     func() (*string, error) { return nil, nil },
+		EndCursor:       func() (*string, error) { return nil, nil },
+		HasNextPage:     func() (bool, error) { return false, nil },
+		HasPreviousPage: func() (bool, error) { return false, nil },
+	}
+}

--- a/sqlboiler/cursor.go
+++ b/sqlboiler/cursor.go
@@ -139,7 +139,7 @@ func rawWhereClause(clause string, args []interface{}) qm.QueryMod {
 }
 
 // convertValueForSQL converts JSON-decoded values to proper SQL types.
-// JSON unmarshaling can change types (e.g., int → float64), so we normalize them here.
+// JSON unmarshaling can change types (e.g., int to float64), so we normalize them here.
 func convertValueForSQL(val any) interface{} {
 	switch v := val.(type) {
 	case string:
@@ -149,25 +149,9 @@ func convertValueForSQL(val any) interface{} {
 		}
 		return v
 
-	case float64:
-		// JSON numbers are always float64, but we might want int for integer columns
-		// For now, pass as-is and let PostgreSQL handle the conversion
+	case float64, int, int64, bool, time.Time, nil:
+		// Pass through types that PostgreSQL handles natively
 		return v
-
-	case int:
-		return v
-
-	case int64:
-		return v
-
-	case bool:
-		return v
-
-	case time.Time:
-		return v
-
-	case nil:
-		return nil
 
 	default:
 		// For unknown types, convert to string


### PR DESCRIPTION
## Summary

This PR simplifies the codebase by extracting helpers, eliminating duplication, and improving readability. All changes are non-breaking and preserve existing functionality.

## Changes

### 1. File Organization
- **Split `models.go`** into `page_args.go` and `page_info.go` for better organization
- **Added `NewEmptyPageInfo()`** constructor for convenient empty PageInfo creation

### 2. Helper Extraction

#### `cursor/paginator.go`
- Extracted `parsePageArgs()` helper to consolidate duplicate validation logic
- Both `New()` and `BuildFetchParams()` now share this code
- Removed dead code: unused `defaultOrderBy` and `buildOrderBy()` function
- **Saved:** ~50 lines

#### `cursor/schema.go`
- Extracted `fixedFieldsToSorts()` helper method
- Eliminated repeated fieldSpec-to-Sort conversion code
- **Saved:** ~25 lines

#### `quotafill/quotafill.go`
- Extracted `argsForEncoder()` and `getSortBy()` helpers
- Eliminated 4 instances of duplicated cursor args building
- **Saved:** ~30 lines

### 3. Code Simplification

#### `offset/cursor.go`
- Simplified `DecodeCursor()` with early return pattern
- Clearer control flow, removed unnecessary variable pre-declarations

#### `sqlboiler/cursor.go`
- Consolidated pass-through switch cases
- **Reduced:** 15 lines → 3 lines

### 4. Test Coverage
- Added comprehensive test for `NewEmptyPageInfo()`
- Verifies all fields return correct nil/false values

## Impact

- ✅ **Net reduction:** ~50 lines of code (108 insertions, 186 deletions)
- ✅ **All tests passing:** 175/175 specs (added 1 new test)
- ✅ **No breaking changes:** All public APIs preserved
- ✅ **No behavior changes:** Functionality remains identical
- ✅ **Improved maintainability:** Less duplication, clearer code organization

## Commits

1. `feat(core): add NewEmptyPageInfo and refactor file organization`
2. `refactor: extract helpers and simplify code across packages`
3. `test(core): add test coverage for NewEmptyPageInfo`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)