### PR TITLE
feat: Unified Paginator[T] API with Fetcher pattern and functional options

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,310 +1,458 @@
 # Migration Guide: v0.3.0 to v2.0
 
-This guide helps you migrate from go-paging v0.3.0 to paging-go v2.0.
+This guide helps you migrate from paging-go v0.3.0 to v2.0.
 
 ## Overview
 
-v2.0 combines two major improvements:
+v2.0 introduces major changes to the API:
 
-1. **Modular architecture** - Separate packages for offset, cursor, and quota-fill pagination
-2. **Repository rename** - Aligned with organizational naming standards: `go-paging` → `paging-go/v2`
-3. **API consistency** - Type rename: `OrderBy` → `Sort`
-4. **Schema pattern** - Ensures encoder/sort order consistency for cursor and quota-fill
+1. **Modular Package Structure** - Strategies moved to separate packages (`offset/`, `cursor/`, `quotafill/`)
+2. **Fetcher Pattern** - All strategies now take `Fetcher[T]` as their first parameter
+3. **Unified Paginator Interface** - All strategies implement the same `Paginator[T].Paginate()` method
+4. **Functional Options** - Page size limits moved from constructors to per-request options
+5. **Simplified BuildConnection** - Connection builders work with `*Page[T]` result type
+6. **Consistent Metadata** - All strategies return rich metadata for observability
 
 ## Breaking Changes Summary
 
 | Change | Old (v0.3.0) | New (v2.0) |
-|--------|-------------|-----------|
-| **Module path** | `github.com/nrfta/go-paging` | `github.com/nrfta/paging-go/v2` |
-| **Constructor** | `paging.NewOffsetPaginator()` | `offset.New()` |
-| **Type** | `paging.OffsetPaginator` | `offset.Paginator` |
-| **Sort type** | `paging.OrderBy` | `paging.Sort` |
-| **Cursor encoding** | `paging.EncodeOffsetCursor()` | `offset.EncodeCursor()` |
+|--------|-----------|-----------|
+| **Package imports** | `"github.com/nrfta/paging-go"` | `"github.com/nrfta/paging-go/v2/offset"` |
+| **Constructor** | `paging.NewOffsetPaginator(pageArgs, totalCount)` | `offset.New(fetcher)` |
+| **Page size config** | Constructor parameter | `Paginate()` options |
+| **Pagination method** | Manual count + fetch + `QueryMods()` | `paginator.Paginate(ctx, page, opts...)` |
+| **Result type** | Raw items + separate PageInfo | `*Page[T]` with Nodes, PageInfo, Metadata |
+| **BuildConnection** | Manual edge/node array building | `offset.BuildConnection(result, transform)` |
+| **Cursor strategy** | `paging.NewCursorPaginator(...)` | `cursor.New(fetcher, schema)` |
+| **Quota-fill** | Not available | `quotafill.New(fetcher, filter, schema, opts...)` |
 
 ## Quick Summary
 
 **What you need to change:**
 
-1. Update imports: `"github.com/nrfta/go-paging"` → `"github.com/nrfta/paging-go/v2/offset"`
-2. Change constructor: `paging.NewOffsetPaginator(...)` → `offset.New(...)`
-3. Change type: `paging.OffsetPaginator` → `offset.Paginator`
-4. Rename sort type: `paging.OrderBy` → `paging.Sort`
-5. **New (Recommended):** Use `offset.BuildConnection()` to eliminate 60-80% of boilerplate
+1. Create a `Fetcher[T]` using `sqlboiler.NewFetcher()` with query and count functions
+2. Pass fetcher to strategy constructor: `offset.New(fetcher)` instead of `offset.New(pageArgs, totalCount)`
+3. Move page size config from constructor to `Paginate()` options: `paging.WithMaxSize(100)`
+4. Replace manual fetch + `QueryMods()` with `paginator.Paginate(ctx, page, opts...)`
+5. Update `BuildConnection()` calls to pass `*Page[T]` result instead of raw items
 
 **What stays the same:**
 
 - `paging.PageArgs` usage
-- `paging.PageInfo` type
-- `QueryMods()` method
-- SQLBoiler integration
+- `paging.PageInfo` type and accessors
+- `paging.Connection[T]` and `Edge[T]` types
+- Transform functions signature
+- SQLBoiler integration pattern
 
 **What you gain:**
 
-- ✨ **60-80% less boilerplate** with `offset.BuildConnection()`
-- ✨ Generic `Connection[T]` and `Edge[T]` types
-- ✨ Type-safe transformations with automatic error handling
-- ✨ Modular architecture with cursor and quota-fill pagination support
-- ✨ **Automatic N+1 pattern** - No more manual `limit + 1` with `cursor.BuildFetchParams()`
+- ✨ **Consistent API** across all three pagination strategies
+- ✨ **Reusable fetchers** - define once, use across multiple requests
+- ✨ **Per-request page size limits** via functional options
+- ✨ **Rich metadata** for observability (timing, strategy name, strategy-specific info)
+- ✨ **Easier testing** with mockable `Fetcher[T]` interface
+- ✨ **Simpler strategy switching** - change three lines of code to switch strategies
 
-## Overview
+## Core Concept: The Fetcher Pattern
 
-The library has been refactored to use a modular package structure:
+The biggest change in v2.0 is the introduction of the `Fetcher[T]` interface. Instead of passing `PageArgs` and `totalCount` to constructors, you now create a reusable fetcher that handles database queries.
 
-- **`offset/`** package: Offset-based pagination with cursor encoding
-- **`cursor/`** package: Cursor-based (keyset) pagination
-- **`quotafill/`** package: Filter-aware iterative fetching
-- **`sqlboiler/`** package: SQLBoiler ORM adapter (generic + strategy-specific)
-- **Root package**: Shared types (`PageArgs`, `PageInfo`, `Connection[T]`, `Edge[T]`)
+**Benefits:**
+- **Reusable**: Define once, use across multiple requests with different page sizes
+- **ORM-agnostic**: Works with SQLBoiler, GORM, sqlc, or raw SQL
+- **Strategy-agnostic**: Same fetcher works for offset, cursor, and quota-fill
+- **Testable**: Easy to mock for unit tests
+
+**The Fetcher interface:**
+
+```go
+type Fetcher[T any] interface {
+    Fetch(ctx context.Context, params FetchParams) ([]T, error)
+    Count(ctx context.Context, params FetchParams) (int64, error)
+}
+```
 
 ## Breaking Changes
 
-### Removed: `paging.NewOffsetPaginator()`
+### Constructor signatures changed
 
-The `NewOffsetPaginator()` function and `OffsetPaginator` type have been removed from the root package.
+All strategy constructors now take `Fetcher[T]` as their first parameter:
 
-### Removed: `paging.EncodeOffsetCursor()` / `paging.DecodeOffsetCursor()`
+- **Offset**: `offset.New(fetcher)`
+- **Cursor**: `cursor.New(fetcher, schema)`
+- **Quota-fill**: `quotafill.New(fetcher, filter, schema, opts...)`
 
-Cursor functions moved to `offset` package (see [Cursor Functions](#cursor-functions)).
+### Page size limits moved to Paginate() options
+
+Constructor no longer accepts default limit parameter. Use functional options instead:
+
+```go
+result, err := paginator.Paginate(ctx, page,
+    paging.WithMaxSize(100),      // Cap at 100 items
+    paging.WithDefaultSize(25),   // Default to 25 when First is nil
+)
+```
+
+### Paginate() method returns *Page[T]
+
+Instead of manually fetching data and building connections, call `Paginate()`:
+
+```go
+// Returns *Page[T] with Nodes, PageInfo, and Metadata populated
+result, err := paginator.Paginate(ctx, page, opts...)
+```
+
+### BuildConnection() takes *Page[T] instead of raw items
+
+Connection builders now work with the `*Page[T]` result:
+
+```go
+// Old: pass paginator + raw items
+return offset.BuildConnection(paginator, dbUsers, transform)
+
+// New: pass result from Paginate()
+return offset.BuildConnection(result, transform)
+```
 
 ## Migration Steps
 
-### 1. Update Your Imports
+### 1. Create a Fetcher
 
-Add the offset package import:
+First, create a `Fetcher[T]` using `sqlboiler.NewFetcher()`:
 
 ```go
 import (
-    "github.com/nrfta/paging-go/v2"
-    "github.com/nrfta/paging-go/v2/offset"  // Add this
+    "github.com/nrfta/paging-go/v2/sqlboiler"
+    "github.com/volatiletech/sqlboiler/v4/queries/qm"
+)
+
+fetcher := sqlboiler.NewFetcher(
+    // Query function: returns slice of items
+    func(ctx context.Context, mods ...qm.QueryMod) ([]*models.User, error) {
+        return models.Users(mods...).All(ctx, r.DB)
+    },
+    // Count function: returns total count
+    func(ctx context.Context, mods ...qm.QueryMod) (int64, error) {
+        return models.Users(mods...).Count(ctx, r.DB)
+    },
+    // Converter function: transforms FetchParams to query mods
+    sqlboiler.OffsetToQueryMods,  // For offset pagination
+    // OR: sqlboiler.CursorToQueryMods for cursor/quota-fill
 )
 ```
 
-### 2. Update Paginator Creation
+**Key points:**
+- Query function includes filters, joins, etc. but NOT limit/offset/order (handled by converter)
+- Count function uses same filters as query function
+- Choose converter based on pagination strategy: `OffsetToQueryMods` or `CursorToQueryMods`
 
-**Before:**
+### 2. Update Constructor Calls
+
+Pass the fetcher to strategy constructors instead of PageArgs and count:
+
+**Offset pagination:**
 
 ```go
-paginator := paging.NewOffsetPaginator(pageArgs, totalCount)
+// Old v0.3.0
+totalCount, _ := models.Users().Count(ctx, r.DB)
+paginator := offset.New(page, totalCount)
+
+// New v2.0
+fetcher := sqlboiler.NewFetcher(queryFunc, countFunc, sqlboiler.OffsetToQueryMods)
+paginator := offset.New(fetcher)
 ```
 
-**After:**
+**Cursor pagination:**
 
 ```go
-paginator := offset.New(pageArgs, totalCount)
+// Old v0.3.0
+fetchParams, _ := cursor.BuildFetchParams(page, schema)
+users, _ := fetcher.Fetch(ctx, fetchParams)
+paginator, _ := cursor.New(page, schema, users)
+
+// New v2.0
+fetcher := sqlboiler.NewFetcher(queryFunc, countFunc, sqlboiler.CursorToQueryMods)
+paginator := cursor.New(fetcher, schema)
 ```
 
-**With custom default limit:**
+**Quota-fill pagination:**
 
 ```go
-// Before
-defaultLimit := 100
-paginator := paging.NewOffsetPaginator(pageArgs, totalCount, &defaultLimit)
+// Old v0.3.0
+paginator := quotafill.New(fetcher, filter, schema, opts...)
+result, _ := paginator.Paginate(ctx, page)
 
-// After
-defaultLimit := 100
-paginator := offset.New(pageArgs, totalCount, &defaultLimit)
+// New v2.0 (same, but fetcher creation is now explicit)
+fetcher := sqlboiler.NewFetcher(queryFunc, countFunc, sqlboiler.CursorToQueryMods)
+paginator := quotafill.New(fetcher, filter, schema, opts...)
+result, _ := paginator.Paginate(ctx, page, paging.WithMaxSize(50))
 ```
 
-### 3. Update Type References
+### 3. Replace Manual Fetch with Paginate()
 
-**Before:**
+Instead of calling `QueryMods()` and manually fetching, call `Paginate()`:
 
-```go
-var paginator paging.OffsetPaginator
-```
-
-**After:**
+**Offset example:**
 
 ```go
-var paginator offset.Paginator
-```
-
-### 4. Use BuildConnection (Recommended!)
-
-This is the **biggest improvement** in v1.0. Instead of manually building edges and nodes, use `offset.BuildConnection()`:
-
-**Before (Manual Boilerplate - 15+ lines):**
-
-```go
-func (r *queryResolver) Users(ctx context.Context, page *paging.PageArgs) (*UserConnection, error) {
-    totalCount, _ := models.Users().Count(ctx, r.DB)
-    paginator := paging.NewOffsetPaginator(page, totalCount)
-
-    dbUsers, _ := models.Users(paginator.QueryMods()...).All(ctx, r.DB)
-
-    // Manual boilerplate
-    result := &UserConnection{PageInfo: &paginator.PageInfo}
-    for i, row := range dbUsers {
-        user, err := toDomainUser(row)
-        if err != nil {
-            return nil, err
-        }
-        result.Edges = append(result.Edges, &UserEdge{
-            Cursor: *paging.EncodeOffsetCursor(paginator.Offset + i + 1),
-            Node:   user,
-        })
-        result.Nodes = append(result.Nodes, user)
-    }
-    return result, nil
+// Old v0.3.0
+paginator := offset.New(page, totalCount)
+dbUsers, err := models.Users(paginator.QueryMods()...).All(ctx, r.DB)
+if err != nil {
+    return nil, err
 }
+return offset.BuildConnection(paginator, dbUsers, toDomainUser)
+
+// New v2.0
+paginator := offset.New(fetcher)
+result, err := paginator.Paginate(ctx, page,
+    paging.WithMaxSize(100),
+    paging.WithDefaultSize(25),
+)
+if err != nil {
+    return nil, err
+}
+return offset.BuildConnection(result, toDomainUser)
 ```
 
-**After (BuildConnection - 1 line!):**
+**Cursor example:**
 
 ```go
-func (r *queryResolver) Users(ctx context.Context, page *paging.PageArgs) (*paging.Connection[*User], error) {
-    totalCount, _ := models.Users().Count(ctx, r.DB)
-    paginator := offset.New(page, totalCount)
+// Old v0.3.0
+fetchParams, _ := cursor.BuildFetchParams(page, schema)
+users, _ := fetcher.Fetch(ctx, fetchParams)
+paginator, _ := cursor.New(page, schema, users)
+return cursor.BuildConnection(paginator, users, toDomainUser)
 
-    dbUsers, _ := models.Users(paginator.QueryMods()...).All(ctx, r.DB)
-
-    // One line - library handles everything!
-    return offset.BuildConnection(paginator, dbUsers, toDomainUser)
+// New v2.0
+paginator := cursor.New(fetcher, schema)
+result, err := paginator.Paginate(ctx, page, paging.WithMaxSize(100))
+if err != nil {
+    return nil, err
 }
+return cursor.BuildConnection(result, schema, page, toDomainUser)
+```
 
-// Transform function (database model → domain model)
-func toDomainUser(db *models.User) (*User, error) {
-    return &User{
-        ID:    db.ID,
-        Name:  db.Name,
-        Email: db.Email,
-    }, nil
+### 4. Update BuildConnection() Calls
+
+All `BuildConnection()` functions now take `*Page[T]` as first parameter:
+
+**Offset:**
+
+```go
+// Old: pass paginator + items
+offset.BuildConnection(paginator, items, transform)
+
+// New: pass result from Paginate()
+offset.BuildConnection(result, transform)
+```
+
+**Cursor:**
+
+```go
+// Old: pass paginator + items
+cursor.BuildConnection(paginator, items, transform)
+
+// New: pass result + schema + page
+cursor.BuildConnection(result, schema, page, transform)
+```
+
+**Quota-fill:**
+
+```go
+// Old: manual loop with edges
+edges := make([]*paging.Edge[*Org], len(result.Nodes))
+for i, org := range result.Nodes {
+    domain, _ := toDomain(org)
+    cursorStr, _ := schema.Encode(org)
+    edges[i] = &paging.Edge[*Org]{Cursor: *cursorStr, Node: domain}
 }
+return &paging.Connection[*Org]{Edges: edges, Nodes: nodes, PageInfo: result.PageInfo}, nil
+
+// New: use BuildConnection helper
+quotafill.BuildConnection(result, schema, page, toDomain)
+```
+
+### 5. Move Page Size Config to Options
+
+Page size limits now passed via functional options to `Paginate()`:
+
+```go
+// Old v0.3.0 (constructor parameter)
+defaultLimit := 25
+paginator := offset.New(page, totalCount, &defaultLimit)
+
+// New v2.0 (Paginate options)
+paginator := offset.New(fetcher)
+result, err := paginator.Paginate(ctx, page,
+    paging.WithMaxSize(100),      // Maximum allowed size
+    paging.WithDefaultSize(25),   // Default when First is nil
+)
 ```
 
 **Benefits:**
+- Configure page size per-request without creating new paginator
+- Compose multiple options together
+- Easier to add new options in the future
 
-- ✅ 60-80% less code
-- ✅ No manual cursor encoding
-- ✅ Automatic error handling
-- ✅ Type-safe transformations
-- ✅ Works with both `edges` and `nodes` fields
+## Complete Example: Offset Pagination
 
-### 5. PageInfo Access (No Changes Required!)
-
-**Good news:** PageInfo usage is identical! The `offset.Paginator.PageInfo` field is `paging.PageInfo` - no conversion needed.
+### Before (v0.3.0)
 
 ```go
-// Works exactly the same as before
-pageInfo := paginator.PageInfo
-
-// Or use the helper method
-pageInfo := paginator.GetPageInfo()
-
-// Both return paging.PageInfo directly
-```
-
-## Complete Example
-
-### Before (Old API - Manual Boilerplate)
-
-```go
-package main
+package resolvers
 
 import (
     "context"
-    "database/sql"
-
-    "github.com/nrfta/paging-go/v2"
-    "github.com/my-user/my-app/models"
-)
-
-type UserConnection struct {
-    Edges    []*UserEdge
-    PageInfo *paging.PageInfo
-}
-
-type UserEdge struct {
-    Cursor string
-    Node   *models.User
-}
-
-func GetUsers(ctx context.Context, pageArgs *paging.PageArgs, db *sql.DB) (*UserConnection, error) {
-    // Get total count
-    totalCount, err := models.Users().Count(ctx, db)
-    if err != nil {
-        return nil, err
-    }
-
-    // Create paginator
-    paginator := paging.NewOffsetPaginator(pageArgs, totalCount)
-
-    // Fetch records
-    dbUsers, err := models.Users(paginator.QueryMods()...).All(ctx, db)
-    if err != nil {
-        return nil, err
-    }
-
-    // Manual boilerplate - 15+ lines
-    result := &UserConnection{PageInfo: &paginator.PageInfo}
-    for i, row := range dbUsers {
-        result.Edges = append(result.Edges, &UserEdge{
-            Cursor: *paging.EncodeOffsetCursor(paginator.Offset + i + 1),
-            Node:   row,
-        })
-    }
-
-    return result, nil
-}
-```
-
-### After (New API - BuildConnection)
-
-```go
-package main
-
-import (
-    "context"
-    "database/sql"
-
     "github.com/nrfta/paging-go/v2"
     "github.com/nrfta/paging-go/v2/offset"
     "github.com/my-user/my-app/models"
 )
 
-func GetUsers(ctx context.Context, pageArgs *paging.PageArgs, db *sql.DB) (*paging.Connection[*models.User], error) {
+func (r *queryResolver) Users(ctx context.Context, page *paging.PageArgs) (*paging.Connection[*User], error) {
     // Get total count
-    totalCount, err := models.Users().Count(ctx, db)
+    totalCount, err := models.Users().Count(ctx, r.DB)
     if err != nil {
         return nil, err
     }
 
     // Create paginator
-    paginator := offset.New(pageArgs, totalCount)
+    paginator := offset.New(page, totalCount)
 
     // Fetch records
-    dbUsers, err := models.Users(paginator.QueryMods()...).All(ctx, db)
+    dbUsers, err := models.Users(paginator.QueryMods()...).All(ctx, r.DB)
     if err != nil {
         return nil, err
     }
 
-    // One line - automatic edge/node building with identity transform
-    return offset.BuildConnection(paginator, dbUsers, func(u *models.User) (*models.User, error) {
-        return u, nil  // No transformation needed
-    })
+    // Build connection
+    return offset.BuildConnection(paginator, dbUsers, toDomainUser)
+}
+
+func toDomainUser(db *models.User) (*User, error) {
+    return &User{ID: db.ID, Name: db.Name, Email: db.Email}, nil
 }
 ```
 
-**With transformation (database model → domain model):**
+### After (v2.0)
 
 ```go
-type DomainUser struct {
-    ID       string
-    FullName string
+package resolvers
+
+import (
+    "context"
+    "github.com/nrfta/paging-go/v2"
+    "github.com/nrfta/paging-go/v2/offset"
+    "github.com/nrfta/paging-go/v2/sqlboiler"
+    "github.com/my-user/my-app/models"
+    "github.com/volatiletech/sqlboiler/v4/queries/qm"
+)
+
+func (r *queryResolver) Users(ctx context.Context, page *paging.PageArgs) (*paging.Connection[*User], error) {
+    // 1. Create fetcher (once, reusable)
+    fetcher := sqlboiler.NewFetcher(
+        func(ctx context.Context, mods ...qm.QueryMod) ([]*models.User, error) {
+            return models.Users(mods...).All(ctx, r.DB)
+        },
+        func(ctx context.Context, mods ...qm.QueryMod) (int64, error) {
+            return models.Users(mods...).Count(ctx, r.DB)
+        },
+        sqlboiler.OffsetToQueryMods,
+    )
+
+    // 2. Create paginator (once, reusable)
+    paginator := offset.New(fetcher)
+
+    // 3. Paginate with per-request options
+    result, err := paginator.Paginate(ctx, page,
+        paging.WithMaxSize(100),
+        paging.WithDefaultSize(25),
+    )
+    if err != nil {
+        return nil, err
+    }
+
+    // 4. Build connection
+    return offset.BuildConnection(result, toDomainUser)
 }
 
-func GetUsers(ctx context.Context, pageArgs *paging.PageArgs, db *sql.DB) (*paging.Connection[*DomainUser], error) {
-    totalCount, _ := models.Users().Count(ctx, db)
-    paginator := offset.New(pageArgs, totalCount)
-    dbUsers, _ := models.Users(paginator.QueryMods()...).All(ctx, db)
+func toDomainUser(db *models.User) (*User, error) {
+    return &User{ID: db.ID, Name: db.Name, Email: db.Email}, nil
+}
+```
 
-    // Automatic transformation with error handling
-    return offset.BuildConnection(paginator, dbUsers, func(db *models.User) (*DomainUser, error) {
-        return &DomainUser{
-            ID:       db.ID,
-            FullName: db.Name,
-        }, nil
-    })
+## Complete Example: Cursor Pagination
+
+### Before (v0.3.0)
+
+```go
+func (r *queryResolver) Users(ctx context.Context, page *paging.PageArgs) (*paging.Connection[*User], error) {
+    schema := cursor.NewSchema[*models.User]().
+        Field("created_at", "c", func(u *models.User) any { return u.CreatedAt }).
+        FixedField("id", cursor.DESC, "i", func(u *models.User) any { return u.ID })
+
+    fetcher := sqlboiler.NewFetcher(
+        func(ctx context.Context, mods ...qm.QueryMod) ([]*models.User, error) {
+            mods = append([]qm.QueryMod{qm.Where("is_active = ?", true)}, mods...)
+            return models.Users(mods...).All(ctx, r.DB)
+        },
+        func(ctx context.Context, mods ...qm.QueryMod) (int64, error) {
+            return 0, nil
+        },
+        sqlboiler.CursorToQueryMods,
+    )
+
+    fetchParams, err := cursor.BuildFetchParams(page, schema)
+    if err != nil {
+        return nil, err
+    }
+
+    users, err := fetcher.Fetch(ctx, fetchParams)
+    if err != nil {
+        return nil, err
+    }
+
+    paginator, err := cursor.New(page, schema, users)
+    if err != nil {
+        return nil, err
+    }
+
+    return cursor.BuildConnection(paginator, users, toDomainUser)
+}
+```
+
+### After (v2.0)
+
+```go
+func (r *queryResolver) Users(ctx context.Context, page *paging.PageArgs) (*paging.Connection[*User], error) {
+    // 1. Define schema (once, reusable)
+    schema := cursor.NewSchema[*models.User]().
+        Field("created_at", "c", func(u *models.User) any { return u.CreatedAt }).
+        FixedField("id", cursor.DESC, "i", func(u *models.User) any { return u.ID })
+
+    // 2. Create fetcher (once, reusable)
+    fetcher := sqlboiler.NewFetcher(
+        func(ctx context.Context, mods ...qm.QueryMod) ([]*models.User, error) {
+            mods = append([]qm.QueryMod{qm.Where("is_active = ?", true)}, mods...)
+            return models.Users(mods...).All(ctx, r.DB)
+        },
+        func(ctx context.Context, mods ...qm.QueryMod) (int64, error) {
+            return 0, nil
+        },
+        sqlboiler.CursorToQueryMods,
+    )
+
+    // 3. Create paginator (once, reusable)
+    paginator := cursor.New(fetcher, schema)
+
+    // 4. Paginate
+    result, err := paginator.Paginate(ctx, page, paging.WithMaxSize(100))
+    if err != nil {
+        return nil, err
+    }
+
+    // 5. Build connection
+    return cursor.BuildConnection(result, schema, page, toDomainUser)
 }
 ```
 
@@ -321,7 +469,7 @@ These parts of the API remain unchanged:
 
 Cursor encoding/decoding functions have moved to the offset package and been renamed:
 
-| Old (v0.3.0) | New (v1.0) |
+| Old (v0.3.0) | New (v2.0) |
 |--------------|------------|
 | `paging.EncodeOffsetCursor()` | `offset.EncodeCursor()` |
 | `paging.DecodeOffsetCursor()` | `offset.DecodeCursor()` |
@@ -344,7 +492,7 @@ offsetValue := offset.DecodeCursor(cursor)
 
 ## New: Automatic N+1 Pattern for Cursor Pagination
 
-v1.0 introduces `cursor.BuildFetchParams()` which automatically handles the N+1 pattern, eliminating the need to manually add +1 to your limit.
+v2.0's unified `Paginate()` method automatically handles the N+1 pattern for all strategies, eliminating the need to manually add +1 to your limit.
 
 **Before (Manual N+1):**
 
@@ -390,90 +538,118 @@ This makes cursor pagination consistent with offset and quota-fill pagination, w
 - Decodes the After cursor
 - Returns ready-to-use FetchParams
 
-## Advanced: Generic Connection Types
+## Reusability Benefits
 
-v1.0 introduces generic `Connection[T]` and `Edge[T]` types:
+The new API encourages reusability at every level:
 
-```go
-// Built-in generic types
-type Connection[T any] struct {
-    Edges    []Edge[T]
-    Nodes    []T
-    PageInfo PageInfo
-}
-
-type Edge[T any] struct {
-    Cursor string
-    Node   T
-}
-```
-
-**GraphQL Schema:**
-
-```graphql
-# Use these built-in types with gqlgen
-type UserConnection {
-  edges: [UserEdge!]!
-  nodes: [User!]!
-  pageInfo: PageInfo!
-}
-
-type UserEdge {
-  cursor: String!
-  node: User!
-}
-```
-
-**gqlgen.yml:**
-
-```yaml
-models:
-  UserConnection:
-    model: github.com/nrfta/paging-go/v2.Connection[github.com/my-user/my-app/domain.User]
-```
-
-## Advanced: SQLBoiler Adapter (for library authors)
-
-The SQLBoiler adapter has been refactored for extensibility. **Most users don't need to change anything** - this only affects advanced use cases.
-
-**What changed:**
-
-- Split into `fetcher.go` (generic ORM integration) + `offset.go` (strategy-specific queries)
-- Enables future support for cursor pagination and other ORMs (GORM, sqlc, etc.)
-
-**If you were using internal SQLBoiler functions directly:**
+**Fetcher reusability:**
 
 ```go
-// Before
-mods := sqlboiler.ToQueryMods(params)
+// Define once (e.g., in a repository struct)
+type UserRepository struct {
+    db      *sql.DB
+    fetcher paging.Fetcher[*models.User]
+}
 
-// After
-mods := sqlboiler.OffsetToQueryMods(params)
+func NewUserRepository(db *sql.DB) *UserRepository {
+    return &UserRepository{
+        db: db,
+        fetcher: sqlboiler.NewFetcher(
+            func(ctx context.Context, mods ...qm.QueryMod) ([]*models.User, error) {
+                return models.Users(mods...).All(ctx, db)
+            },
+            func(ctx context.Context, mods ...qm.QueryMod) (int64, error) {
+                return models.Users(mods...).Count(ctx, db)
+            },
+            sqlboiler.OffsetToQueryMods,
+        ),
+    }
+}
+
+// Use across multiple methods
+func (r *UserRepository) ListWithOffset(ctx context.Context, page *paging.PageArgs) (*paging.Connection[*User], error) {
+    paginator := offset.New(r.fetcher)
+    result, _ := paginator.Paginate(ctx, page, paging.WithMaxSize(100))
+    return offset.BuildConnection(result, toDomain)
+}
+
+func (r *UserRepository) ListWithCursor(ctx context.Context, page *paging.PageArgs) (*paging.Connection[*User], error) {
+    // Same fetcher, different strategy!
+    paginator := cursor.New(r.fetcher, userSchema)
+    result, _ := paginator.Paginate(ctx, page, paging.WithMaxSize(100))
+    return cursor.BuildConnection(result, userSchema, page, toDomain)
+}
+```
+
+**Schema reusability (cursor/quota-fill):**
+
+```go
+// Define once at package level
+var userSchema = cursor.NewSchema[*models.User]().
+    Field("created_at", "c", func(u *models.User) any { return u.CreatedAt }).
+    Field("name", "n", func(u *models.User) any { return u.Name }).
+    FixedField("id", cursor.DESC, "i", func(u *models.User) any { return u.ID })
+
+// Reuse in both cursor and quota-fill paginators
+```
+
+**Per-request configuration:**
+
+```go
+// Same paginator, different page sizes per endpoint
+adminPaginator := offset.New(fetcher)
+
+// Admin endpoint: large pages
+result, _ := adminPaginator.Paginate(ctx, page, paging.WithMaxSize(500))
+
+// Public API endpoint: smaller pages
+result, _ := adminPaginator.Paginate(ctx, page, paging.WithMaxSize(50))
 ```
 
 ## Why This Change?
 
-The new modular architecture provides:
+The unified API with Fetcher pattern provides significant benefits:
 
-1. **Eliminates boilerplate**: `BuildConnection()` reduces resolver code by 60-80%
-2. **Type-safe transformations**: Generic transform functions with automatic error handling
-3. **Clearer separation of concerns**: Each pagination strategy in its own package
-4. **Easier to extend**: New strategies (cursor-based, quota-fill) can be added without conflicts
-5. **ORM flexibility**: Easy to add support for GORM, sqlc, or custom ORMs
-6. **Better documentation**: Each package documented independently
-7. **Production-ready**: Comprehensive tests, optimized code, clear patterns
+1. **Consistent API**: All three strategies work the same way - learn once, use everywhere
+2. **Better reusability**: Define fetchers, paginators, and schemas once, use across multiple requests
+3. **Per-request configuration**: No need to create new paginators for different page sizes
+4. **Easier testing**: Mock the `Fetcher[T]` interface for unit tests
+5. **Simpler strategy switching**: Change three lines of code to switch from offset to cursor
+6. **Rich metadata**: Observability for monitoring, debugging, and performance optimization
+7. **ORM-agnostic**: Same pattern works with SQLBoiler, GORM, sqlc, or raw SQL
+8. **Less boilerplate**: Single `Paginate()` call replaces manual fetch + trim logic
 
 ## Migration Checklist
 
-- [ ] Update module import: `"github.com/nrfta/go-paging"` → `"github.com/nrfta/paging-go/v2"`
-- [ ] Update subpackage imports: `"github.com/nrfta/go-paging/offset"` → `"github.com/nrfta/paging-go/v2/offset"`
-- [ ] Replace `paging.NewOffsetPaginator()` with `offset.New()`
-- [ ] Update type references: `paging.OffsetPaginator` → `offset.Paginator`
-- [ ] Rename sort type: `paging.OrderBy` → `paging.Sort`
-- [ ] Replace manual edge/node building with `offset.BuildConnection()`
-- [ ] Update cursor functions (if used): `paging.EncodeOffsetCursor` → `offset.EncodeCursor`
+### For Offset Pagination:
+- [ ] Add `sqlboiler` package import
+- [ ] Create `Fetcher[T]` using `sqlboiler.NewFetcher()`
+- [ ] Update constructor: `offset.New(page, totalCount)` → `offset.New(fetcher)`
+- [ ] Replace manual fetch with `paginator.Paginate(ctx, page, opts...)`
+- [ ] Move page size config from constructor to `WithMaxSize()` / `WithDefaultSize()` options
+- [ ] Update `BuildConnection()`: pass `result` instead of `paginator` + `items`
 - [ ] Run tests to verify everything works
-- [ ] Enjoy 60-80% less boilerplate code! 🎉
+
+### For Cursor Pagination:
+- [ ] Create `Fetcher[T]` using `sqlboiler.NewFetcher()` with `CursorToQueryMods`
+- [ ] Update constructor: `cursor.New(page, schema, items)` → `cursor.New(fetcher, schema)`
+- [ ] Remove manual `BuildFetchParams()` and `fetcher.Fetch()` calls
+- [ ] Replace with `paginator.Paginate(ctx, page, opts...)`
+- [ ] Update `BuildConnection()`: pass `result, schema, page, transform` instead of `paginator, items, transform`
+- [ ] Run tests to verify everything works
+
+### For Quota-fill Pagination:
+- [ ] Create `Fetcher[T]` using `sqlboiler.NewFetcher()` with `CursorToQueryMods`
+- [ ] Constructor already takes fetcher (no change needed)
+- [ ] Add per-request options to `Paginate()` call
+- [ ] Replace manual connection building loop with `quotafill.BuildConnection()`
+- [ ] Run tests to verify everything works
+
+### General:
+- [ ] Review metadata access patterns if needed
+- [ ] Consider refactoring to reuse fetchers, paginators, and schemas
+- [ ] Update documentation and comments to reflect new API
+- [ ] Enjoy the cleaner, more consistent API! 🎉
 
 ## Need Help?
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,6 +1,7 @@
 package paging_test
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,7 +26,42 @@ type DomainUser struct {
 	EmailAddr string
 }
 
+// mockOffsetFetcher creates a simple in-memory fetcher for testing
+func mockOffsetFetcher(allUsers []DBUser, totalCount int64) paging.Fetcher[DBUser] {
+	return &offsetTestFetcher{
+		allUsers:   allUsers,
+		totalCount: totalCount,
+	}
+}
+
+type offsetTestFetcher struct {
+	allUsers   []DBUser
+	totalCount int64
+}
+
+func (f *offsetTestFetcher) Fetch(ctx context.Context, params paging.FetchParams) ([]DBUser, error) {
+	start := params.Offset
+	end := start + params.Limit
+	if start >= len(f.allUsers) {
+		return []DBUser{}, nil
+	}
+	if end > len(f.allUsers) {
+		end = len(f.allUsers)
+	}
+	return f.allUsers[start:end], nil
+}
+
+func (f *offsetTestFetcher) Count(ctx context.Context, params paging.FetchParams) (int64, error) {
+	return f.totalCount, nil
+}
+
 var _ = Describe("Connection and Edge", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
 	Describe("BuildConnection", func() {
 		It("should build a connection with edges and nodes", func() {
 			// Setup: Create mock database records
@@ -146,19 +182,26 @@ var _ = Describe("Connection and Edge", func() {
 
 	Describe("offset.BuildConnection", func() {
 		It("should build connection with offset-based cursors", func() {
-			// Setup: Create paginator
-			first := 2
-			pageArgs := &paging.PageArgs{
-				First: &first,
-			}
-			totalCount := int64(10)
-			paginator := offset.New(pageArgs, totalCount)
-
-			// Setup: Mock database records
-			dbUsers := []DBUser{
+			// Setup: Create mock data
+			allUsers := []DBUser{
 				{ID: 1, Name: "Alice", Email: "alice@example.com"},
 				{ID: 2, Name: "Bob", Email: "bob@example.com"},
+				{ID: 3, Name: "Charlie", Email: "charlie@example.com"},
+				{ID: 4, Name: "Diana", Email: "diana@example.com"},
+				{ID: 5, Name: "Eve", Email: "eve@example.com"},
 			}
+
+			// Create paginator with fetcher
+			fetcher := mockOffsetFetcher(allUsers, 10)
+			paginator := offset.New(fetcher)
+
+			// Paginate first page (2 items)
+			first := 2
+			pageArgs := &paging.PageArgs{First: &first}
+
+			page, err := paginator.Paginate(ctx, pageArgs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(page.Nodes).To(HaveLen(2))
 
 			// Setup: Transform function
 			transform := func(db DBUser) (*DomainUser, error) {
@@ -170,7 +213,7 @@ var _ = Describe("Connection and Edge", func() {
 			}
 
 			// Execute: Build connection using offset helper
-			conn, err := offset.BuildConnection(paginator, dbUsers, transform)
+			conn, err := offset.BuildConnection(page, transform)
 
 			// Assert: No error
 			Expect(err).ToNot(HaveOccurred())
@@ -183,8 +226,6 @@ var _ = Describe("Connection and Edge", func() {
 
 			// Assert: Edges have sequential cursors
 			Expect(conn.Edges).To(HaveLen(2))
-			// First item at offset 0 → cursor encodes offset 1
-			// Second item at offset 1 → cursor encodes offset 2
 			cursor1 := offset.DecodeCursor(&conn.Edges[0].Cursor)
 			cursor2 := offset.DecodeCursor(&conn.Edges[1].Cursor)
 			Expect(cursor1).To(Equal(1))
@@ -198,21 +239,32 @@ var _ = Describe("Connection and Edge", func() {
 		})
 
 		It("should handle second page with offset", func() {
-			// Setup: Second page starting at offset 2
+			// Setup: Create mock data
+			allUsers := []DBUser{
+				{ID: 1, Name: "Alice", Email: "alice@example.com"},
+				{ID: 2, Name: "Bob", Email: "bob@example.com"},
+				{ID: 3, Name: "Charlie", Email: "charlie@example.com"},
+				{ID: 4, Name: "Diana", Email: "diana@example.com"},
+				{ID: 5, Name: "Eve", Email: "eve@example.com"},
+			}
+
+			// Create paginator
+			fetcher := mockOffsetFetcher(allUsers, 10)
+			paginator := offset.New(fetcher)
+
+			// Paginate second page (starting at offset 2)
 			first := 2
 			cursor := offset.EncodeCursor(2)
 			pageArgs := &paging.PageArgs{
 				First: &first,
 				After: cursor,
 			}
-			totalCount := int64(10)
-			paginator := offset.New(pageArgs, totalCount)
 
-			// Setup: Mock records for second page
-			dbUsers := []DBUser{
-				{ID: 3, Name: "Charlie", Email: "charlie@example.com"},
-				{ID: 4, Name: "Diana", Email: "diana@example.com"},
-			}
+			page, err := paginator.Paginate(ctx, pageArgs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(page.Nodes).To(HaveLen(2))
+			Expect(page.Nodes[0].ID).To(Equal(3)) // 3rd user (offset 2)
+			Expect(page.Nodes[1].ID).To(Equal(4)) // 4th user (offset 3)
 
 			transform := func(db DBUser) (*DomainUser, error) {
 				return &DomainUser{
@@ -221,7 +273,7 @@ var _ = Describe("Connection and Edge", func() {
 				}, nil
 			}
 
-			conn, err := offset.BuildConnection(paginator, dbUsers, transform)
+			conn, err := offset.BuildConnection(page, transform)
 
 			Expect(err).ToNot(HaveOccurred())
 
@@ -235,79 +287,55 @@ var _ = Describe("Connection and Edge", func() {
 
 	Describe("Real-world use case", func() {
 		It("should eliminate repository boilerplate", func() {
-			// This test demonstrates the before/after from the research document
-
-			// BEFORE: Manual boilerplate (what users had to write)
-			beforeConnection := func(dbUsers []DBUser, paginator offset.Paginator) (*paging.Connection[*DomainUser], error) {
-				result := &paging.Connection[*DomainUser]{
-					PageInfo: paginator.PageInfo,
-				}
-
-				for i, row := range dbUsers {
-					// Manual transformation
-					user := &DomainUser{
-						ID:        fmt.Sprintf("user-%d", row.ID),
-						FullName:  row.Name,
-						EmailAddr: row.Email,
-					}
-
-					// Manual cursor encoding
-					cursor := *offset.EncodeCursor(paginator.Offset + i + 1)
-
-					// Manual edge building
-					result.Edges = append(result.Edges, paging.Edge[*DomainUser]{
-						Cursor: cursor,
-						Node:   user,
-					})
-
-					// Manual nodes building
-					result.Nodes = append(result.Nodes, user)
-				}
-
-				return result, nil
-			}
-
-			// AFTER: Using BuildConnection (new API)
-			afterConnection := func(dbUsers []DBUser, paginator offset.Paginator) (*paging.Connection[*DomainUser], error) {
-				return offset.BuildConnection(paginator, dbUsers, func(db DBUser) (*DomainUser, error) {
-					return &DomainUser{
-						ID:        fmt.Sprintf("user-%d", db.ID),
-						FullName:  db.Name,
-						EmailAddr: db.Email,
-					}, nil
-				})
-			}
-
-			// Test: Both approaches produce identical results
-			first := 3
-			pageArgs := &paging.PageArgs{First: &first}
-			totalCount := int64(10)
-			paginator := offset.New(pageArgs, totalCount)
-
-			dbUsers := []DBUser{
+			// Setup: Create mock data
+			allUsers := []DBUser{
 				{ID: 1, Name: "Alice", Email: "alice@example.com"},
 				{ID: 2, Name: "Bob", Email: "bob@example.com"},
 				{ID: 3, Name: "Charlie", Email: "charlie@example.com"},
+				{ID: 4, Name: "Diana", Email: "diana@example.com"},
+				{ID: 5, Name: "Eve", Email: "eve@example.com"},
 			}
 
-			beforeResult, beforeErr := beforeConnection(dbUsers, paginator)
-			afterResult, afterErr := afterConnection(dbUsers, paginator)
+			fetcher := mockOffsetFetcher(allUsers, 10)
+			paginator := offset.New(fetcher)
 
-			// Assert: Both succeed
-			Expect(beforeErr).ToNot(HaveOccurred())
-			Expect(afterErr).ToNot(HaveOccurred())
+			first := 3
+			pageArgs := &paging.PageArgs{First: &first}
 
-			// Assert: Results are identical
-			Expect(afterResult.Nodes).To(HaveLen(len(beforeResult.Nodes)))
-			Expect(afterResult.Edges).To(HaveLen(len(beforeResult.Edges)))
+			page, err := paginator.Paginate(ctx, pageArgs)
+			Expect(err).ToNot(HaveOccurred())
 
-			for i := range beforeResult.Nodes {
-				Expect(afterResult.Nodes[i].ID).To(Equal(beforeResult.Nodes[i].ID))
-				Expect(afterResult.Edges[i].Cursor).To(Equal(beforeResult.Edges[i].Cursor))
-			}
+			// AFTER: Using BuildConnection (new API)
+			// This is now the ONLY way to build a connection
+			conn, err := offset.BuildConnection(page, func(db DBUser) (*DomainUser, error) {
+				return &DomainUser{
+					ID:        fmt.Sprintf("user-%d", db.ID),
+					FullName:  db.Name,
+					EmailAddr: db.Email,
+				}, nil
+			})
 
-			// The key difference: AFTER is 1 line vs BEFORE is 15+ lines
-			// This is the 60-80% boilerplate reduction mentioned in the research
+			// Assert: Succeeds
+			Expect(err).ToNot(HaveOccurred())
+
+			// Assert: Results are correct
+			Expect(conn.Nodes).To(HaveLen(3))
+			Expect(conn.Edges).To(HaveLen(3))
+
+			Expect(conn.Nodes[0].ID).To(Equal("user-1"))
+			Expect(conn.Nodes[1].ID).To(Equal("user-2"))
+			Expect(conn.Nodes[2].ID).To(Equal("user-3"))
+
+			// Verify cursors
+			cursor1 := offset.DecodeCursor(&conn.Edges[0].Cursor)
+			cursor2 := offset.DecodeCursor(&conn.Edges[1].Cursor)
+			cursor3 := offset.DecodeCursor(&conn.Edges[2].Cursor)
+			Expect(cursor1).To(Equal(1))
+			Expect(cursor2).To(Equal(2))
+			Expect(cursor3).To(Equal(3))
+
+			// The key difference: BuildConnection is 1 line vs manual boilerplate of 15+ lines
+			// This achieves the 60-80% boilerplate reduction mentioned in the research
 		})
 	})
 })

--- a/cursor/paginator.go
+++ b/cursor/paginator.go
@@ -1,264 +1,155 @@
 package cursor
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/nrfta/paging-go/v2"
 )
 
-const defaultLimitVal = 50
-
 // PageArgs represents pagination arguments.
-// This is a subset of the main PageArgs type to avoid import cycles.
-// Implementations should provide the page size (First), cursor position (After),
-// and sorting configuration (SortBy).
 type PageArgs interface {
 	GetFirst() *int
 	GetAfter() *string
 	GetSortBy() []paging.Sort
 }
 
-// Paginator is the paginator for cursor-based pagination.
-// It encapsulates limit, cursor position, and page metadata for keyset queries.
-//
-// Unlike offset pagination, cursor pagination:
-//   - Does not require totalCount
-//   - Uses cursor position instead of offset
-//   - Provides O(1) performance regardless of page depth
-//   - Requires composite indexes on sort columns
-//
-// Paginator now requires a Schema to enforce encoder/OrderBy matching.
-type Paginator struct {
-	limit    int
-	cursor   *paging.CursorPosition
-	PageInfo paging.PageInfo
-	orderBy  []paging.Sort
-	encoder  interface{} // Stored as interface{} to avoid making Paginator generic
+// Paginator implements paging.Paginator[T] for cursor-based pagination.
+type Paginator[T any] struct {
+	fetcher paging.Fetcher[T]
+	schema  *Schema[T]
 }
 
-// parsedParams holds the common parsed state from PageArgs and Schema.
-type parsedParams[T any] struct {
-	encoder paging.CursorEncoder[T]
-	orderBy []paging.Sort
-	limit   int
-	cursor  *paging.CursorPosition
+// New creates a cursor paginator that implements paging.Paginator[T].
+//
+// Example:
+//
+//	fetcher := sqlboiler.NewFetcher(queryFunc, countFunc, sqlboiler.CursorToQueryMods)
+//	paginator := cursor.New(fetcher, schema)
+//	result, err := paginator.Paginate(ctx, args, paging.WithMaxSize(100))
+func New[T any](fetcher paging.Fetcher[T], schema *Schema[T]) paging.Paginator[T] {
+	return &Paginator[T]{
+		fetcher: fetcher,
+		schema:  schema,
+	}
 }
 
-// parsePageArgs extracts and validates common parameters from PageArgs and Schema.
-func parsePageArgs[T any](page PageArgs, schema *Schema[T], defaultLimit *int) (parsedParams[T], error) {
-	encoder, err := schema.EncoderFor(page)
+// Paginate executes cursor-based pagination and returns a Page[T].
+func (p *Paginator[T]) Paginate(
+	ctx context.Context,
+	args *paging.PageArgs,
+	opts ...paging.PaginateOption,
+) (*paging.Page[T], error) {
+	// Apply page size config
+	pageConfig := paging.ApplyPaginateOptions(args, opts...)
+	limit := pageConfig.EffectiveLimit(args)
+
+	// Get encoder for current sort
+	encoder, err := p.schema.EncoderFor(args)
 	if err != nil {
-		return parsedParams[T]{}, err
+		return nil, err
 	}
 
-	var sortBy []paging.Sort
-	if page != nil && page.GetSortBy() != nil {
-		sortBy = page.GetSortBy()
-	}
-	orderBy := schema.BuildOrderBy(sortBy)
-
-	limit := defaultLimitVal
-	if defaultLimit != nil {
-		limit = *defaultLimit
-	}
-	if page != nil && page.GetFirst() != nil && *page.GetFirst() > 0 {
-		limit = *page.GetFirst()
-	}
-	if limit == 0 {
-		limit = defaultLimitVal
+	// Decode cursor
+	var cursorPos *paging.CursorPosition
+	if args != nil && args.GetAfter() != nil {
+		cursorPos, _ = encoder.Decode(*args.GetAfter())
 	}
 
-	var cursor *paging.CursorPosition
-	if page != nil && page.GetAfter() != nil {
-		cursor, _ = encoder.Decode(*page.GetAfter())
+	// Build ORDER BY
+	orderBy := p.schema.BuildOrderBy(getSortBy(args))
+
+	// Fetch with N+1 pattern
+	params := paging.FetchParams{
+		Limit:   limit + 1,
+		Cursor:  cursorPos,
+		OrderBy: orderBy,
 	}
-
-	return parsedParams[T]{
-		encoder: encoder,
-		orderBy: orderBy,
-		limit:   limit,
-		cursor:  cursor,
-	}, nil
-}
-
-// New creates a new cursor paginator using a Schema.
-//
-// Parameters:
-//   - page: Pagination arguments including page size, cursor, and sorting
-//   - schema: Schema that defines sortable fields, fixed fields, and cursor encoding
-//   - items: The items fetched from the database (should be LIMIT+1 for accurate HasNextPage)
-//   - defaultLimit: Optional default page size (defaults to 50 if not provided)
-//
-// The paginator automatically handles:
-//   - PageArgs validation: Returns error if sort fields are invalid
-//   - Encoder/OrderBy matching: Schema guarantees they match
-//   - N+1 pattern: Detects if you fetched LIMIT+1 for accurate HasNextPage detection
-//   - Item trimming: Trims results to requested limit if N+1 was fetched
-//   - Default page size of 50 records
-//   - Zero-value protection to prevent divide-by-zero errors
-//   - Cursor decoding using the schema's encoder
-//   - PageInfo generation based on fetched results
-//
-// Best Practice (N+1 Pattern):
-//   - Fetch LIMIT+1 records from database (e.g., if limit=10, fetch 11)
-//   - Pass all fetched items to New()
-//   - Paginator will detect N+1 and set HasNextPage accurately
-//   - BuildConnection will automatically trim to LIMIT items
-//
-// Example usage:
-//
-//	// Define schema once at app startup
-//	schema := cursor.NewSchema[*models.User]().
-//	    Field("name", "n", func(u *models.User) any { return u.Name }).
-//	    FixedField("id", cursor.DESC, "i", func(u *models.User) any { return u.ID })
-//
-//	// Fetch LIMIT+1 for accurate HasNextPage
-//	fetchParams := cursor.BuildFetchParams(pageArgs, schema)
-//	users, _ := fetcher.Fetch(ctx, fetchParams)
-//
-//	paginator, err := cursor.New(pageArgs, schema, users)
-//	if err != nil {
-//	    return nil, err  // Invalid sort field in pageArgs
-//	}
-//	conn, _ := cursor.BuildConnection(paginator, users, toDomainUser)
-func New[T any](
-	page PageArgs,
-	schema *Schema[T],
-	items []T,
-	defaultLimit ...*int,
-) (Paginator, error) {
-	var defLimit *int
-	if len(defaultLimit) > 0 {
-		defLimit = defaultLimit[0]
-	}
-
-	params, err := parsePageArgs(page, schema, defLimit)
+	items, err := p.fetcher.Fetch(ctx, params)
 	if err != nil {
-		return Paginator{}, err
+		return nil, err
 	}
 
-	// N+1 pattern: Check if we got more items than requested
-	hasNextPage := len(items) > params.limit
-
-	// Trim items to the requested limit
-	trimmedItems := items
+	// Detect hasNextPage and trim
+	hasNextPage := len(items) > limit
 	if hasNextPage {
-		trimmedItems = items[:params.limit]
+		items = items[:limit]
 	}
 
-	pageInfo := newCursorBasedPageInfo(params.encoder, trimmedItems, params.limit, params.cursor, hasNextPage)
+	// Build PageInfo
+	pageInfo := buildCursorPageInfo(encoder, items, cursorPos, hasNextPage)
 
-	return Paginator{
-		limit:    params.limit,
-		cursor:   params.cursor,
-		PageInfo: pageInfo,
-		orderBy:  params.orderBy,
-		encoder:  params.encoder,
+	return &paging.Page[T]{
+		Nodes:    items,
+		PageInfo: &pageInfo,
+		Metadata: paging.Metadata{Strategy: "cursor"},
 	}, nil
 }
 
-// BuildFetchParams creates FetchParams with automatic N+1 pattern for accurate HasNextPage detection.
-// It uses the schema to validate PageArgs, get the encoder, and build the complete OrderBy clause.
-func BuildFetchParams[T any](
-	page PageArgs,
-	schema *Schema[T],
-) (paging.FetchParams, error) {
-	params, err := parsePageArgs(page, schema, nil)
-	if err != nil {
-		return paging.FetchParams{}, err
+// getSortBy safely extracts SortBy from args.
+func getSortBy(args *paging.PageArgs) []paging.Sort {
+	if args == nil || args.GetSortBy() == nil {
+		return nil
 	}
-
-	return paging.FetchParams{
-		Limit:   params.limit + 1, // N+1 for HasNextPage detection
-		Cursor:  params.cursor,
-		OrderBy: params.orderBy,
-	}, nil
+	return args.GetSortBy()
 }
 
-// GetPageInfo returns the PageInfo for this paginator.
-// PageInfo contains functions to retrieve pagination metadata like
-// cursors and whether next/previous pages exist.
-//
-// Note: TotalCount always returns nil for cursor pagination.
-func (p *Paginator) GetPageInfo() paging.PageInfo {
-	return p.PageInfo
+// buildCursorPageInfo creates PageInfo for cursor-based pagination.
+func buildCursorPageInfo[T any](
+	encoder paging.CursorEncoder[T],
+	items []T,
+	currentCursor *paging.CursorPosition,
+	hasNextPage bool,
+) paging.PageInfo {
+	return paging.PageInfo{
+		TotalCount: func() (*int, error) {
+			return nil, nil
+		},
+
+		StartCursor: func() (*string, error) {
+			if len(items) == 0 {
+				return nil, nil
+			}
+			return encoder.Encode(items[0])
+		},
+
+		EndCursor: func() (*string, error) {
+			if len(items) == 0 {
+				return nil, nil
+			}
+			return encoder.Encode(items[len(items)-1])
+		},
+
+		HasNextPage: func() (bool, error) {
+			return hasNextPage, nil
+		},
+
+		HasPreviousPage: func() (bool, error) {
+			return currentCursor != nil, nil
+		},
+	}
 }
 
-// GetLimit returns the page size limit.
-func (p *Paginator) GetLimit() int {
-	return p.limit
-}
-
-// GetCursor returns the cursor position for this paginator.
-// Returns nil if this is the first page.
-func (p *Paginator) GetCursor() *paging.CursorPosition {
-	return p.cursor
-}
-
-// GetOrderBy returns the OrderBy directives for this paginator.
-func (p *Paginator) GetOrderBy() []paging.Sort {
-	return p.orderBy
-}
-
-// BuildConnection creates a Relay-compliant GraphQL connection from a slice of items.
-// It handles transformation from database models to domain models and automatically
-// generates composite key cursors for each item.
+// BuildConnection transforms a Page[From] to a Connection[To] for GraphQL.
+// Uses schema's encoder to generate composite key cursors.
 //
-// This function eliminates the manual boilerplate of building edges and nodes arrays,
-// reducing repository code by 60-80%.
+// Example:
 //
-// The encoder is obtained from the paginator (which got it from the schema),
-// ensuring encoder/OrderBy matching is enforced.
-//
-// Type parameters:
-//   - From: Source type (e.g., *models.User from SQLBoiler)
-//   - To: Target type (e.g., *domain.User for GraphQL)
-//
-// Parameters:
-//   - paginator: The cursor paginator containing pagination state and encoder
-//   - items: Slice of database records to transform
-//   - transform: Function that converts database model to domain model
-//
-// Returns a Connection with edges, nodes, and pageInfo populated.
-//
-// Example usage:
-//
-//	// Before (manual boilerplate - 25+ lines):
-//	result := &domain.UserConnection{PageInfo: &paginator.PageInfo}
-//	for _, row := range dbUsers {
-//	    user, err := toDomainUser(row)
-//	    if err != nil { return nil, err }
-//	    cursor, _ := encoder.Encode(row)
-//	    result.Edges = append(result.Edges, domain.Edge{
-//	        Cursor: *cursor,
-//	        Node:   user,
-//	    })
-//	    result.Nodes = append(result.Nodes, user)
-//	}
-//
-//	// After (using BuildConnection - 1 line):
-//	return cursor.BuildConnection(paginator, dbUsers, toDomainUser)
+//	result, _ := paginator.Paginate(ctx, args, paging.WithMaxSize(100))
+//	conn, _ := cursor.BuildConnection(result, schema, toDomainUser)
 func BuildConnection[From any, To any](
-	paginator Paginator,
-	items []From,
+	page *paging.Page[From],
+	schema *Schema[From],
+	args *paging.PageArgs,
 	transform func(From) (To, error),
 ) (*paging.Connection[To], error) {
-	// Get encoder from paginator (type assert)
-	encoder, ok := paginator.encoder.(paging.CursorEncoder[From])
-	if !ok {
-		return nil, fmt.Errorf("paginator encoder type mismatch")
-	}
-
-	// N+1 pattern: Trim items to the requested limit
-	// If caller fetched LIMIT+1, we only want to return LIMIT items in the connection
-	trimmedItems := items
-	if len(items) > paginator.limit {
-		trimmedItems = items[:paginator.limit]
+	encoder, err := schema.EncoderFor(args)
+	if err != nil {
+		return nil, err
 	}
 
 	return paging.BuildConnection(
-		trimmedItems,
-		paginator.PageInfo,
+		page.Nodes,
+		*page.PageInfo,
 		func(i int, item From) string {
 			cursor, _ := encoder.Encode(item)
 			if cursor == nil {
@@ -268,54 +159,4 @@ func BuildConnection[From any, To any](
 		},
 		transform,
 	)
-}
-
-// newCursorBasedPageInfo creates PageInfo for cursor-based pagination.
-// It uses the fetched items to generate cursors and determine page boundaries.
-//
-// Key differences from offset pagination:
-//   - TotalCount always returns nil (cursor pagination doesn't need total count)
-//   - HasNextPage uses N+1 pattern: passed in based on whether we got LIMIT+1 records
-//   - StartCursor/EndCursor encode the first/last items' sort columns
-//   - HasPreviousPage checks if cursor is not nil (has cursor = not first page)
-func newCursorBasedPageInfo[T any](
-	encoder paging.CursorEncoder[T],
-	items []T,
-	limit int,
-	currentCursor *paging.CursorPosition,
-	hasNextPage bool,
-) paging.PageInfo {
-	return paging.PageInfo{
-		// TotalCount: Not available for cursor pagination
-		TotalCount: func() (*int, error) {
-			return nil, nil
-		},
-
-		// StartCursor: Encode first item (or nil if empty)
-		StartCursor: func() (*string, error) {
-			if len(items) == 0 {
-				return nil, nil
-			}
-			return encoder.Encode(items[0])
-		},
-
-		// EndCursor: Encode last item (or nil if empty)
-		EndCursor: func() (*string, error) {
-			if len(items) == 0 {
-				return nil, nil
-			}
-			return encoder.Encode(items[len(items)-1])
-		},
-
-		// HasNextPage: Determined by N+1 pattern (caller fetches LIMIT+1)
-		// True if we got more items than the requested limit
-		HasNextPage: func() (bool, error) {
-			return hasNextPage, nil
-		},
-
-		// HasPreviousPage: True if we have a cursor (implies we're not on the first page)
-		HasPreviousPage: func() (bool, error) {
-			return currentCursor != nil, nil
-		},
-	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -9,12 +9,21 @@ import "context"
 //
 // Example implementations:
 //   - offset.Paginator: Traditional offset/limit pagination
-//   - cursor.Paginator: High-performance cursor-based pagination (Phase 2)
-//   - quotafill.Wrapper: Filtering-aware pagination (Phase 3)
+//   - cursor.Paginator: High-performance cursor-based pagination
+//   - quotafill.Wrapper: Filtering-aware pagination
+//
+// Example usage:
+//
+//	paginator := offset.New(fetcher)
+//	result, err := paginator.Paginate(ctx, args,
+//	    paging.WithMaxSize(100),
+//	    paging.WithDefaultSize(25),
+//	)
 type Paginator[T any] interface {
 	// Paginate executes pagination and returns a page of results.
 	// The PageArgs contain the page size (First) and cursor position (After).
-	Paginate(ctx context.Context, args *PageArgs) (*Page[T], error)
+	// Options like WithMaxSize and WithDefaultSize configure per-request page size limits.
+	Paginate(ctx context.Context, args *PageArgs, opts ...PaginateOption) (*Page[T], error)
 }
 
 // Page represents a single page of paginated results.
@@ -54,6 +63,11 @@ type Metadata struct {
 	// SafeguardHit indicates if a safeguard was triggered during quota-fill.
 	// Values: nil (no safeguard), "max_iterations", "max_records", "timeout"
 	SafeguardHit *string
+
+	// Offset is the current offset position for offset-based pagination.
+	// This field is only populated when Strategy is "offset".
+	// Used by BuildConnection to generate accurate cursors for multi-page results.
+	Offset int
 }
 
 // Fetcher abstracts database queries for any ORM or database layer.

--- a/offset/offset_suite_test.go
+++ b/offset/offset_suite_test.go
@@ -1,10 +1,8 @@
 package offset_test
 
 import (
-	"reflect"
 	"testing"
 
-	"github.com/aarondl/sqlboiler/v4/queries/qm"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,9 +10,4 @@ import (
 func TestOffset(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Offset Suite")
-}
-
-// modTypeName returns the type name of a query mod for assertion purposes.
-func modTypeName(mod qm.QueryMod) string {
-	return reflect.TypeOf(mod).String()
 }

--- a/page_args.go
+++ b/page_args.go
@@ -1,5 +1,116 @@
 package paging
 
+import "fmt"
+
+const (
+	// DefaultPageSize is the default number of items per page when not specified.
+	DefaultPageSize = 50
+
+	// DefaultMaxPageSize is the default maximum page size allowed.
+	// This protects against resource exhaustion from unreasonably large page requests.
+	DefaultMaxPageSize = 1000
+)
+
+// PageConfig holds pagination configuration options.
+// Use NewPageConfig() to create a config with sensible defaults,
+// then customize using the With* methods.
+//
+// Example:
+//
+//	config := paging.NewPageConfig().WithMaxSize(500)
+//	limit := config.EffectiveLimit(args)
+type PageConfig struct {
+	// DefaultSize is the page size used when not specified in PageArgs.
+	DefaultSize int
+
+	// MaxSize is the maximum allowed page size. Requests exceeding this
+	// will be capped to MaxSize (not rejected).
+	MaxSize int
+}
+
+// NewPageConfig creates a PageConfig with sensible defaults:
+// - DefaultSize: 50
+// - MaxSize: 1000
+func NewPageConfig() *PageConfig {
+	return &PageConfig{
+		DefaultSize: DefaultPageSize,
+		MaxSize:     DefaultMaxPageSize,
+	}
+}
+
+// WithDefaultSize sets the default page size and returns the config for chaining.
+func (c *PageConfig) WithDefaultSize(size int) *PageConfig {
+	if size > 0 {
+		c.DefaultSize = size
+	}
+	return c
+}
+
+// WithMaxSize sets the maximum page size and returns the config for chaining.
+func (c *PageConfig) WithMaxSize(size int) *PageConfig {
+	if size > 0 {
+		c.MaxSize = size
+	}
+	return c
+}
+
+// EffectiveLimit returns the page size to use, applying defaults and caps.
+// - If args is nil or First is nil/zero, returns DefaultSize
+// - If First exceeds MaxSize, returns MaxSize
+// - Otherwise returns First
+func (c *PageConfig) EffectiveLimit(args *PageArgs) int {
+	if c == nil {
+		c = NewPageConfig()
+	}
+
+	defaultSize := c.DefaultSize
+	if defaultSize <= 0 {
+		defaultSize = DefaultPageSize
+	}
+
+	maxSize := c.MaxSize
+	if maxSize <= 0 {
+		maxSize = DefaultMaxPageSize
+	}
+
+	if args == nil || args.First == nil || *args.First <= 0 {
+		return defaultSize
+	}
+
+	if *args.First > maxSize {
+		return maxSize
+	}
+
+	return *args.First
+}
+
+// Validate checks if the page size exceeds MaxSize and returns an error if so.
+// Unlike EffectiveLimit which caps silently, Validate returns an error for
+// explicit rejection of invalid requests.
+func (c *PageConfig) Validate(args *PageArgs) error {
+	if c == nil {
+		c = NewPageConfig()
+	}
+
+	if args == nil || args.First == nil {
+		return nil
+	}
+
+	maxSize := c.MaxSize
+	if maxSize <= 0 {
+		maxSize = DefaultMaxPageSize
+	}
+
+	if *args.First > maxSize {
+		return &PageSizeError{
+			Requested: *args.First,
+			Maximum:   maxSize,
+		}
+	}
+
+	return nil
+}
+
 // PageArgs represents pagination query parameters.
 // It follows the Relay cursor pagination specification with First (page size),
 // After (cursor), and SortBy (sort configuration) fields.
@@ -59,4 +170,133 @@ func (pa *PageArgs) GetAfter() *string {
 // GetSortBy returns the list of sort specifications.
 func (pa *PageArgs) GetSortBy() []Sort {
 	return pa.SortBy
+}
+
+// ValidatePageSize validates that the requested page size does not exceed the maximum.
+// Returns an error if First is set and exceeds maxPageSize.
+//
+// Deprecated: Use PageConfig.Validate() instead for clearer configuration.
+// This function is kept for backwards compatibility.
+//
+// If maxPageSize is 0, uses DefaultMaxPageSize (1000).
+//
+// Example with custom limit:
+//
+//	func (r *resolver) Users(ctx context.Context, args *paging.PageArgs) (*UserConnection, error) {
+//	    if err := paging.ValidatePageSize(args, 500); err != nil {
+//	        return nil, err
+//	    }
+//	    // ... proceed with pagination
+//	}
+//
+// Preferred approach using PageConfig:
+//
+//	config := paging.NewPageConfig().WithMaxSize(500)
+//	if err := config.Validate(args); err != nil {
+//	    return nil, err
+//	}
+func ValidatePageSize(args *PageArgs, maxPageSize int) error {
+	config := NewPageConfig()
+	if maxPageSize > 0 {
+		config.WithMaxSize(maxPageSize)
+	}
+	return config.Validate(args)
+}
+
+// Validate validates the PageArgs using DefaultMaxPageSize (1000).
+// This is a convenience method that uses the default PageConfig.
+//
+// For custom limits, use ValidateWith:
+//
+//	config := paging.NewPageConfig().WithMaxSize(500)
+//	if err := args.ValidateWith(config); err != nil {
+//	    return nil, err
+//	}
+func (pa *PageArgs) Validate() error {
+	return NewPageConfig().Validate(pa)
+}
+
+// ValidateWith validates the PageArgs using a custom PageConfig.
+// This allows specifying custom maximum page sizes per endpoint.
+//
+// Example:
+//
+//	config := paging.NewPageConfig().WithMaxSize(100)
+//	if err := args.ValidateWith(config); err != nil {
+//	    return nil, err // Page size too large
+//	}
+func (pa *PageArgs) ValidateWith(config *PageConfig) error {
+	return config.Validate(pa)
+}
+
+// PageSizeError is returned when the requested page size exceeds the maximum allowed.
+type PageSizeError struct {
+	Requested int
+	Maximum   int
+}
+
+func (e *PageSizeError) Error() string {
+	return fmt.Sprintf("requested page size %d exceeds maximum allowed page size of %d",
+		e.Requested, e.Maximum)
+}
+
+// PaginateOption configures page size limits for a pagination request.
+// Options are passed to Paginate() to configure per-request limits.
+//
+// Example:
+//
+//	result, err := paginator.Paginate(ctx, args,
+//	    paging.WithMaxSize(100),
+//	    paging.WithDefaultSize(25),
+//	)
+type PaginateOption func(*paginateConfig)
+
+// paginateConfig holds page size configuration for a pagination request.
+type paginateConfig struct {
+	maxSize     int
+	defaultSize int
+}
+
+// WithMaxSize sets the maximum page size for this request.
+// If the requested size exceeds this, it will be capped to maxSize.
+//
+// Example:
+//
+//	result, err := paginator.Paginate(ctx, args, paging.WithMaxSize(100))
+func WithMaxSize(size int) PaginateOption {
+	return func(c *paginateConfig) {
+		if size > 0 {
+			c.maxSize = size
+		}
+	}
+}
+
+// WithDefaultSize sets the default page size for this request.
+// Used when args.First is nil or zero.
+//
+// Example:
+//
+//	result, err := paginator.Paginate(ctx, args, paging.WithDefaultSize(25))
+func WithDefaultSize(size int) PaginateOption {
+	return func(c *paginateConfig) {
+		if size > 0 {
+			c.defaultSize = size
+		}
+	}
+}
+
+// ApplyPaginateOptions applies functional options and returns a PageConfig.
+// This is an internal helper used by all paginators.
+func ApplyPaginateOptions(args *PageArgs, opts ...PaginateOption) *PageConfig {
+	cfg := &paginateConfig{
+		maxSize:     DefaultMaxPageSize,
+		defaultSize: DefaultPageSize,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return &PageConfig{
+		MaxSize:     cfg.maxSize,
+		DefaultSize: cfg.defaultSize,
+	}
 }

--- a/page_args_test.go
+++ b/page_args_test.go
@@ -99,3 +99,289 @@ var _ = Describe("NewEmptyPageInfo", func() {
 		Expect(hasPrev).To(BeFalse())
 	})
 })
+
+var _ = Describe("ValidatePageSize", func() {
+	It("should accept nil args", func() {
+		err := paging.ValidatePageSize(nil, 100)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should accept args with nil First", func() {
+		args := &paging.PageArgs{}
+		err := paging.ValidatePageSize(args, 100)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should accept page size within limit", func() {
+		first := 50
+		args := &paging.PageArgs{First: &first}
+		err := paging.ValidatePageSize(args, 100)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should accept page size equal to limit", func() {
+		first := 100
+		args := &paging.PageArgs{First: &first}
+		err := paging.ValidatePageSize(args, 100)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should reject page size exceeding limit", func() {
+		first := 1010
+		args := &paging.PageArgs{First: &first}
+		err := paging.ValidatePageSize(args, 1000)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("1010"))
+		Expect(err.Error()).To(ContainSubstring("1000"))
+		Expect(err.Error()).To(ContainSubstring("exceeds maximum"))
+	})
+
+	It("should return PageSizeError with correct values", func() {
+		first := 150
+		args := &paging.PageArgs{First: &first}
+		err := paging.ValidatePageSize(args, 100)
+		Expect(err).To(HaveOccurred())
+
+		var pageSizeErr *paging.PageSizeError
+		Expect(err).To(BeAssignableToTypeOf(pageSizeErr))
+
+		pageSizeErr = err.(*paging.PageSizeError)
+		Expect(pageSizeErr.Requested).To(Equal(150))
+		Expect(pageSizeErr.Maximum).To(Equal(100))
+	})
+
+	It("should handle very large page size requests", func() {
+		first := 999999
+		args := &paging.PageArgs{First: &first}
+		err := paging.ValidatePageSize(args, 100)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("999999"))
+	})
+
+	It("should use DefaultMaxPageSize when maxPageSize is 0", func() {
+		first := 1500
+		args := &paging.PageArgs{First: &first}
+		err := paging.ValidatePageSize(args, 0) // Should use DefaultMaxPageSize (1000)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("1500"))
+		Expect(err.Error()).To(ContainSubstring("1000"))
+	})
+
+	It("should accept page size within DefaultMaxPageSize when using 0", func() {
+		first := 500
+		args := &paging.PageArgs{First: &first}
+		err := paging.ValidatePageSize(args, 0) // Should use DefaultMaxPageSize (1000)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("PageArgs.Validate", func() {
+	It("should validate using DefaultMaxPageSize", func() {
+		first := 500
+		args := &paging.PageArgs{First: &first}
+		err := args.Validate()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should reject page size exceeding DefaultMaxPageSize", func() {
+		first := 1500
+		args := &paging.PageArgs{First: &first}
+		err := args.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("1500"))
+		Expect(err.Error()).To(ContainSubstring("1000"))
+	})
+
+	It("should accept nil args", func() {
+		var args *paging.PageArgs
+		err := args.Validate()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should accept page size equal to DefaultMaxPageSize", func() {
+		first := 1000
+		args := &paging.PageArgs{First: &first}
+		err := args.Validate()
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("PageConfig", func() {
+	Describe("NewPageConfig", func() {
+		It("should create config with default values", func() {
+			config := paging.NewPageConfig()
+			Expect(config.DefaultSize).To(Equal(paging.DefaultPageSize))
+			Expect(config.MaxSize).To(Equal(paging.DefaultMaxPageSize))
+		})
+	})
+
+	Describe("WithDefaultSize", func() {
+		It("should set default size", func() {
+			config := paging.NewPageConfig().WithDefaultSize(25)
+			Expect(config.DefaultSize).To(Equal(25))
+		})
+
+		It("should ignore zero or negative values", func() {
+			config := paging.NewPageConfig().WithDefaultSize(0)
+			Expect(config.DefaultSize).To(Equal(paging.DefaultPageSize))
+
+			config = paging.NewPageConfig().WithDefaultSize(-10)
+			Expect(config.DefaultSize).To(Equal(paging.DefaultPageSize))
+		})
+
+		It("should support method chaining", func() {
+			config := paging.NewPageConfig().
+				WithDefaultSize(25).
+				WithMaxSize(500)
+			Expect(config.DefaultSize).To(Equal(25))
+			Expect(config.MaxSize).To(Equal(500))
+		})
+	})
+
+	Describe("WithMaxSize", func() {
+		It("should set max size", func() {
+			config := paging.NewPageConfig().WithMaxSize(500)
+			Expect(config.MaxSize).To(Equal(500))
+		})
+
+		It("should ignore zero or negative values", func() {
+			config := paging.NewPageConfig().WithMaxSize(0)
+			Expect(config.MaxSize).To(Equal(paging.DefaultMaxPageSize))
+
+			config = paging.NewPageConfig().WithMaxSize(-10)
+			Expect(config.MaxSize).To(Equal(paging.DefaultMaxPageSize))
+		})
+	})
+
+	Describe("EffectiveLimit", func() {
+		It("should return default size when args is nil", func() {
+			config := paging.NewPageConfig().WithDefaultSize(25)
+			limit := config.EffectiveLimit(nil)
+			Expect(limit).To(Equal(25))
+		})
+
+		It("should return default size when First is nil", func() {
+			config := paging.NewPageConfig().WithDefaultSize(25)
+			args := &paging.PageArgs{}
+			limit := config.EffectiveLimit(args)
+			Expect(limit).To(Equal(25))
+		})
+
+		It("should return default size when First is zero", func() {
+			config := paging.NewPageConfig().WithDefaultSize(25)
+			zero := 0
+			args := &paging.PageArgs{First: &zero}
+			limit := config.EffectiveLimit(args)
+			Expect(limit).To(Equal(25))
+		})
+
+		It("should return default size when First is negative", func() {
+			config := paging.NewPageConfig().WithDefaultSize(25)
+			negative := -10
+			args := &paging.PageArgs{First: &negative}
+			limit := config.EffectiveLimit(args)
+			Expect(limit).To(Equal(25))
+		})
+
+		It("should return First when within limits", func() {
+			config := paging.NewPageConfig().WithMaxSize(100)
+			first := 50
+			args := &paging.PageArgs{First: &first}
+			limit := config.EffectiveLimit(args)
+			Expect(limit).To(Equal(50))
+		})
+
+		It("should cap First to MaxSize when exceeded", func() {
+			config := paging.NewPageConfig().WithMaxSize(100)
+			first := 500
+			args := &paging.PageArgs{First: &first}
+			limit := config.EffectiveLimit(args)
+			Expect(limit).To(Equal(100))
+		})
+
+		It("should handle nil config gracefully", func() {
+			var config *paging.PageConfig
+			first := 50
+			args := &paging.PageArgs{First: &first}
+			limit := config.EffectiveLimit(args)
+			Expect(limit).To(Equal(50))
+		})
+
+		It("should use system defaults when config values are zero", func() {
+			config := &paging.PageConfig{DefaultSize: 0, MaxSize: 0}
+			limit := config.EffectiveLimit(nil)
+			Expect(limit).To(Equal(paging.DefaultPageSize))
+		})
+	})
+
+	Describe("Validate", func() {
+		It("should accept valid page size", func() {
+			config := paging.NewPageConfig().WithMaxSize(100)
+			first := 50
+			args := &paging.PageArgs{First: &first}
+			err := config.Validate(args)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should accept page size equal to max", func() {
+			config := paging.NewPageConfig().WithMaxSize(100)
+			first := 100
+			args := &paging.PageArgs{First: &first}
+			err := config.Validate(args)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject page size exceeding max", func() {
+			config := paging.NewPageConfig().WithMaxSize(100)
+			first := 150
+			args := &paging.PageArgs{First: &first}
+			err := config.Validate(args)
+			Expect(err).To(HaveOccurred())
+
+			var pageSizeErr *paging.PageSizeError
+			Expect(err).To(BeAssignableToTypeOf(pageSizeErr))
+			pageSizeErr = err.(*paging.PageSizeError)
+			Expect(pageSizeErr.Requested).To(Equal(150))
+			Expect(pageSizeErr.Maximum).To(Equal(100))
+		})
+
+		It("should accept nil args", func() {
+			config := paging.NewPageConfig()
+			err := config.Validate(nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should accept nil First", func() {
+			config := paging.NewPageConfig()
+			args := &paging.PageArgs{}
+			err := config.Validate(args)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should handle nil config gracefully", func() {
+			var config *paging.PageConfig
+			first := 500
+			args := &paging.PageArgs{First: &first}
+			err := config.Validate(args)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("PageArgs.ValidateWith", func() {
+	It("should validate using custom config", func() {
+		config := paging.NewPageConfig().WithMaxSize(100)
+		first := 50
+		args := &paging.PageArgs{First: &first}
+		err := args.ValidateWith(config)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should reject page size exceeding custom max", func() {
+		config := paging.NewPageConfig().WithMaxSize(100)
+		first := 150
+		args := &paging.PageArgs{First: &first}
+		err := args.ValidateWith(config)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/tests/offset_integration_test.go
+++ b/tests/offset_integration_test.go
@@ -14,17 +14,7 @@ import (
 
 var _ = Describe("Offset Pagination Integration Tests", func() {
 	var userIDs []string
-
-	BeforeEach(func() {
-		// Clean tables before each test
-		err := CleanupTables(ctx, container.DB)
-		Expect(err).ToNot(HaveOccurred())
-
-		// Seed test data
-		userIDs, err = SeedUsers(ctx, container.DB, 25)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(userIDs).To(HaveLen(25))
-	})
+	var userPaginator paging.Paginator[*models.User]
 
 	// Helper to create a standard user fetcher with offset strategy
 	createUserFetcher := func() paging.Fetcher[*models.User] {
@@ -39,145 +29,111 @@ var _ = Describe("Offset Pagination Integration Tests", func() {
 		)
 	}
 
+	BeforeEach(func() {
+		// Clean tables before each test
+		err := CleanupTables(ctx, container.DB)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Seed test data
+		userIDs, err = SeedUsers(ctx, container.DB, 25)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(userIDs).To(HaveLen(25))
+
+		// Create paginator (reusable)
+		fetcher := createUserFetcher()
+		userPaginator = offset.New(fetcher)
+	})
+
 	Describe("Basic Offset Pagination", func() {
 		It("should paginate users with default page size using SQLBoiler", func() {
-			// Get total count using SQLBoiler
-			totalCount, err := models.Users().Count(ctx, container.DB)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(totalCount).To(Equal(int64(25)))
-
 			// Create paginator (first page)
 			first := 10
-			pageArgs := &paging.PageArgs{
+			pageArgs := paging.WithSortBy(&paging.PageArgs{
 				First: &first,
-			}
-			paginator := offset.New(pageArgs, totalCount)
+			}, "created_at", true)
 
-			// Create fetcher
-			fetcher := createUserFetcher()
-
-			// Fetch with pagination
-			fetchParams := paging.FetchParams{
-				Offset:  paginator.Offset,
-				Limit:   paginator.Limit,
-				OrderBy: []paging.Sort{{Column: "created_at", Desc: true}},
-			}
-			users, err := fetcher.Fetch(ctx, fetchParams)
+			// Paginate
+			page, err := userPaginator.Paginate(ctx, pageArgs)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify results
-			Expect(users).To(HaveLen(10))
-			Expect(paginator.Limit).To(Equal(10))
-			Expect(paginator.Offset).To(Equal(0))
+			Expect(page.Nodes).To(HaveLen(10))
+			Expect(page.Metadata.Strategy).To(Equal("offset"))
 
 			// Verify PageInfo
-			hasNext, err := paginator.PageInfo.HasNextPage()
+			hasNext, err := page.PageInfo.HasNextPage()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasNext).To(BeTrue())
 
-			hasPrev, err := paginator.PageInfo.HasPreviousPage()
+			hasPrev, err := page.PageInfo.HasPreviousPage()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasPrev).To(BeFalse())
 
-			total, err := paginator.PageInfo.TotalCount()
+			total, err := page.PageInfo.TotalCount()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*total).To(Equal(25))
 		})
 
 		It("should paginate to second page", func() {
-			totalCount, err := models.Users().Count(ctx, container.DB)
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create second page cursor
 			first := 10
 			cursor := offset.EncodeCursor(10) // After first 10 records
-			pageArgs := &paging.PageArgs{
+			pageArgs := paging.WithSortBy(&paging.PageArgs{
 				First: &first,
 				After: cursor,
-			}
-			paginator := offset.New(pageArgs, totalCount)
+			}, "created_at", true)
 
-			fetcher := createUserFetcher()
-
-			fetchParams := paging.FetchParams{
-				Offset:  paginator.Offset,
-				Limit:   paginator.Limit,
-				OrderBy: []paging.Sort{{Column: "created_at", Desc: true}},
-			}
-			users, err := fetcher.Fetch(ctx, fetchParams)
+			page, err := userPaginator.Paginate(ctx, pageArgs)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify
-			Expect(users).To(HaveLen(10))
-			Expect(paginator.Offset).To(Equal(10))
+			Expect(page.Nodes).To(HaveLen(10))
 
 			// Still has next page (25 total, we're at 10-19)
-			hasNext, _ := paginator.PageInfo.HasNextPage()
+			hasNext, _ := page.PageInfo.HasNextPage()
 			Expect(hasNext).To(BeTrue())
 
-			hasPrev, _ := paginator.PageInfo.HasPreviousPage()
+			hasPrev, _ := page.PageInfo.HasPreviousPage()
 			Expect(hasPrev).To(BeTrue())
 		})
 
 		It("should handle last page correctly", func() {
-			totalCount, err := models.Users().Count(ctx, container.DB)
-			Expect(err).ToNot(HaveOccurred())
-
 			// Go to last page
 			first := 10
 			cursor := offset.EncodeCursor(20) // After 20 records, should get last 5
-			pageArgs := &paging.PageArgs{
+			pageArgs := paging.WithSortBy(&paging.PageArgs{
 				First: &first,
 				After: cursor,
-			}
-			paginator := offset.New(pageArgs, totalCount)
+			}, "created_at", true)
 
-			fetcher := createUserFetcher()
-
-			fetchParams := paging.FetchParams{
-				Offset:  paginator.Offset,
-				Limit:   paginator.Limit,
-				OrderBy: []paging.Sort{{Column: "created_at", Desc: true}},
-			}
-			users, err := fetcher.Fetch(ctx, fetchParams)
+			page, err := userPaginator.Paginate(ctx, pageArgs)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Last page has 5 items (25 total - 20 offset)
-			Expect(users).To(HaveLen(5))
+			Expect(page.Nodes).To(HaveLen(5))
 
 			// No next page
-			hasNext, _ := paginator.PageInfo.HasNextPage()
+			hasNext, _ := page.PageInfo.HasNextPage()
 			Expect(hasNext).To(BeFalse())
 
 			// Has previous page
-			hasPrev, _ := paginator.PageInfo.HasPreviousPage()
+			hasPrev, _ := page.PageInfo.HasPreviousPage()
 			Expect(hasPrev).To(BeTrue())
 		})
 	})
 
 	Describe("Custom Sorting", func() {
 		It("should sort by email ascending", func() {
-			totalCount, err := models.Users().Count(ctx, container.DB)
-			Expect(err).ToNot(HaveOccurred())
-
 			// Sort by email
 			first := 5
 			pageArgs := paging.WithSortBy(&paging.PageArgs{First: &first}, "email", false)
-			paginator := offset.New(pageArgs, totalCount)
 
-			fetcher := createUserFetcher()
-
-			fetchParams := paging.FetchParams{
-				Offset:  paginator.Offset,
-				Limit:   paginator.Limit,
-				OrderBy: []paging.Sort{{Column: "email", Desc: false}},
-			}
-			users, err := fetcher.Fetch(ctx, fetchParams)
+			page, err := userPaginator.Paginate(ctx, pageArgs)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(users).To(HaveLen(5))
+			Expect(page.Nodes).To(HaveLen(5))
 			// Verify sorted order (user1@, user10@, user11@, ...)
-			Expect(users[0].Email).To(HaveSuffix("@example.com"))
+			Expect(page.Nodes[0].Email).To(HaveSuffix("@example.com"))
 		})
 	})
 
@@ -191,34 +147,28 @@ var _ = Describe("Offset Pagination Integration Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(userIDs).To(HaveLen(100))
 
-			totalCount, err := models.Users().Count(ctx, container.DB)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(totalCount).To(Equal(int64(100)))
-
+			// Create new paginator for larger dataset
 			fetcher := createUserFetcher()
+			paginator := offset.New(fetcher)
 
 			// Paginate through all pages
 			pageSize := 25
-			pageArgs := &paging.PageArgs{
-				First: &pageSize,
-			}
+			var currentCursor *string
 
 			for page := 0; page < 4; page++ {
-				paginator := offset.New(pageArgs, totalCount)
+				pageArgs := paging.WithSortBy(&paging.PageArgs{
+					First: &pageSize,
+					After: currentCursor,
+				}, "created_at", true)
 
-				fetchParams := paging.FetchParams{
-					Offset:  paginator.Offset,
-					Limit:   paginator.Limit,
-					OrderBy: []paging.Sort{{Column: "created_at", Desc: true}},
-				}
-				users, err := fetcher.Fetch(ctx, fetchParams)
+				result, err := paginator.Paginate(ctx, pageArgs)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(users).To(HaveLen(25))
+				Expect(result.Nodes).To(HaveLen(25))
 
 				// Advance cursor for next page
 				if page < 3 {
 					nextCursor := offset.EncodeCursor((page + 1) * pageSize)
-					pageArgs.After = nextCursor
+					currentCursor = nextCursor
 				}
 			}
 		})
@@ -232,13 +182,8 @@ var _ = Describe("Offset Pagination Integration Tests", func() {
 		})
 
 		It("should paginate posts with published filter", func() {
-			// Get count of published posts using SQLBoiler
-			totalCount, err := models.Posts(qm.Where("published_at IS NOT NULL")).Count(ctx, container.DB)
-			Expect(err).ToNot(HaveOccurred())
-
 			first := 10
-			pageArgs := &paging.PageArgs{First: &first}
-			paginator := offset.New(pageArgs, totalCount)
+			pageArgs := paging.WithSortBy(&paging.PageArgs{First: &first}, "published_at", true)
 
 			// Create fetcher with WHERE filter
 			fetcher := sqlboiler.NewFetcher(
@@ -254,21 +199,17 @@ var _ = Describe("Offset Pagination Integration Tests", func() {
 				sqlboiler.OffsetToQueryMods,
 			)
 
-			fetchParams := paging.FetchParams{
-				Offset:  paginator.Offset,
-				Limit:   paginator.Limit,
-				OrderBy: []paging.Sort{{Column: "published_at", Desc: true}},
-			}
-			posts, err := fetcher.Fetch(ctx, fetchParams)
+			paginator := offset.New(fetcher)
+			page, err := paginator.Paginate(ctx, pageArgs)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(posts).To(HaveLen(10))
+			Expect(page.Nodes).To(HaveLen(10))
 			// Verify all posts are published
-			for _, post := range posts {
+			for _, post := range page.Nodes {
 				Expect(post.PublishedAt).ToNot(BeNil())
 			}
 
-			hasNext, _ := paginator.PageInfo.HasNextPage()
+			hasNext, _ := page.PageInfo.HasNextPage()
 			Expect(hasNext).To(BeTrue()) // 25 users * 3 posts * 2/3 published = 50 posts
 		})
 	})


### PR DESCRIPTION
## Overview

This PR unifies all three pagination strategies (offset, cursor, quotafill) around a common `Paginator[T]` interface with the Fetcher pattern and functional options. This is a major API improvement that makes the library more consistent, flexible, and easier to use.

## Breaking Changes

### 1. Unified Paginator[T] Interface
All strategies now implement the same interface:
```go
type Paginator[T any] interface {
    Paginate(ctx context.Context, args *PageArgs, opts ...PaginateOption) (*Page[T], error)
}
```

### 2. Fetcher Pattern
All constructors now take `Fetcher[T]` as the first parameter:
- `offset.New(fetcher)`
- `cursor.New(fetcher, schema)`
- `quotafill.New(fetcher, filter, schema, opts...)`

### 3. Functional Options
Page size limits moved from constructors to `Paginate()` options:
- `paging.WithMaxSize(100)` - cap maximum page size
- `paging.WithDefaultSize(25)` - set default when First is nil

### 4. Page[T] Result Type
`Paginate()` returns `*Page[T]` with:
- `Nodes` - the actual items
- `PageInfo` - pagination metadata
- `Metadata` - observability data (strategy, timing, offset, etc.)

### 5. Simplified BuildConnection
All BuildConnection functions now take the `*Page[T]` result:
- `offset.BuildConnection(page, transform)`
- `cursor.BuildConnection(page, schema, args, transform)`
- `quotafill.BuildConnection(page, schema, args, transform)`

## Removed/Deprecated

- **offset**: `QueryMods()` method removed (use `Paginate()` instead)
- **cursor**: `BuildFetchParams()` deprecated (use `Paginate()` instead)
- **quotafill**: `WithPageConfig()` option removed (use `Paginate()` options)

## Benefits

✨ **Consistent API** - All three strategies work the same way
✨ **Reusable fetchers** - Define once, use across multiple requests
✨ **Per-request configuration** - Page size limits via functional options
✨ **Rich metadata** - Observability data for monitoring and debugging
✨ **Easier testing** - Mockable `Fetcher[T]` interface
✨ **Simpler strategy switching** - Change 3 lines of code to switch strategies

## Migration Example

### Before (v0.3.0)
```go
totalCount, _ := models.Users().Count(ctx, r.DB)
paginator := offset.New(page, totalCount)
dbUsers, _ := models.Users(paginator.QueryMods()...).All(ctx, r.DB)
conn, _ := offset.BuildConnection(paginator, dbUsers, toDomainUser)
```

### After (v2.0)
```go
fetcher := sqlboiler.NewFetcher(queryFunc, countFunc, sqlboiler.OffsetToQueryMods)
paginator := offset.New(fetcher)
result, _ := paginator.Paginate(ctx, page, paging.WithMaxSize(100))
conn, _ := offset.BuildConnection(result, toDomainUser)
```

## Testing

✅ **204 tests passing** across all packages:
- Root package: 48 passed
- Cursor: 41 passed
- Offset: 10 passed
- Quotafill: 23 passed
- SQLBoiler: 32 passed
- Integration tests: 50 passed

## Documentation

- ✅ README.md updated with new API examples
- ✅ MIGRATION.md updated with comprehensive migration guide from v0.3.0 to v2.0
- ✅ All code examples updated to show unified API pattern
- ✅ Added "API Design Philosophy" section explaining the design decisions

## Files Changed

**Core API:**
- `interfaces.go` - Added `Offset` to Metadata, updated Paginator[T] interface
- `page_args.go` - Added PaginateOption types and functional options

**Offset Strategy:**
- `offset/paginator.go` - Implemented Paginator[T], added Fetcher pattern
- `offset/paginator_test.go` - Updated tests for new API

**Cursor Strategy:**
- `cursor/paginator.go` - Implemented Paginator[T], added Fetcher pattern
- `cursor/paginator_test.go` - Updated tests for new API

**Quotafill Strategy:**
- `quotafill/quotafill.go` - Updated to use PaginateOption

**Tests:**
- `connection_test.go` - Updated BuildConnection tests
- `tests/offset_integration_test.go` - Rewritten for new API
- `tests/cursor_integration_test.go` - Updated for new API
- `tests/security_test.go` - Updated for new API

**Documentation:**
- `README.md` - Complete rewrite with unified API examples
- `MIGRATION.md` - Detailed v0.3.0 → v2.0 migration guide

## Reviewers

This is a major breaking change. Please review:
1. API design consistency across all three strategies
2. Migration guide completeness
3. Test coverage for new API
4. Documentation clarity

See MIGRATION.md for the complete migration guide.