### PR TITLE
fix(offset): correct StartCursor and EndCursor to reference current page items

### DIFF
--- a/offset/paginator_test.go
+++ b/offset/paginator_test.go
@@ -116,11 +116,15 @@ var _ = Describe("Paginator", func() {
 			hasPreviousPage, _ := page.PageInfo.HasPreviousPage()
 			Expect(hasPreviousPage).To(Equal(true))
 
+			// StartCursor should point to first item on current page (offset 20)
+			// Cursor encoding is offset + 1, so cursor = 21
 			startCursor, _ := page.PageInfo.StartCursor()
-			Expect(startCursor).To(Equal(offset.EncodeCursor(0)))
+			Expect(startCursor).To(Equal(offset.EncodeCursor(21)))
 
+			// EndCursor should point to last item on current page (offset 29)
+			// Cursor encoding is offset + 1, so cursor = 30
 			endCursor, _ := page.PageInfo.EndCursor()
-			Expect(endCursor).To(Equal(offset.EncodeCursor(90)))
+			Expect(endCursor).To(Equal(offset.EncodeCursor(30)))
 		})
 	})
 


### PR DESCRIPTION
## Summary

Fixes a critical bug in offset-based pagination where `StartCursor` and `EndCursor` were pointing to incorrect positions, causing pagination to jump to wrong offsets when navigating between pages.

### The Problem

- `StartCursor` always returned offset 0 (first page of entire dataset)
- `EndCursor` returned the offset to the **last page** of the entire dataset instead of the last item on the **current page**

This caused pagination to jump incorrectly. For example, with 428 total records and page size 10:
- First page would return `EndCursor` pointing to offset 420 (last page)
- Using that cursor for the second page would jump to offset 420 instead of offset 10
- Result: skipped 41 pages of data

### The Fix

Both cursors now correctly reference items on the **current page**:
- `StartCursor`: Returns cursor of the first item on current page (`currentOffset + 1`)
- `EndCursor`: Returns cursor of the last item on current page, accounting for partial pages at the end
- Both handle empty result sets properly by returning `nil`

### Changes

- Updated `buildOffsetPageInfo` in `offset/paginator.go` to calculate cursors based on current page position
- Updated test expectations in `offset/paginator_test.go` to verify correct cursor behavior
- Improved documentation to clarify cursor semantics

## Test Plan

- [x] All 10 offset package tests pass
- [x] All 154 tests pass across entire codebase  
- [x] Integration tests with real PostgreSQL pass
- [x] Verified cursor values are correct for first, middle, and last pages
- [x] Verified partial pages (last page with fewer items) return correct EndCursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)